### PR TITLE
Normalize section labels and preload default song sections

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -134,6 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
         isMeasureMode: false,
         isRhymeMode: false,
         currentSong: null,
+        defaultSections: "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]",
         resizeObserver: null,
         copyDropdown: null,
         hasUnsavedChanges: false, // Track unsaved changes
@@ -168,10 +169,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Enhanced song creation with metadata
         createSong(title, lyrics = '', chords = '') {
+            const normalizedLyrics = lyrics.trim()
+                ? this.normalizeSectionLabels(lyrics)
+                : this.defaultSections;
             return {
                 id: Date.now().toString(),
                 title,
-                lyrics,
+                lyrics: normalizedLyrics,
                 chords,
                 key: '',
                 tempo: 120,
@@ -181,6 +185,41 @@ document.addEventListener('DOMContentLoaded', () => {
                 lastEditedAt: new Date().toISOString(),
                 tags: []
             };
+        },
+
+        normalizeSectionLabels(text = '') {
+            const sectionKeywords = [
+                'intro',
+                'verse',
+                'prechorus',
+                'chorus',
+                'bridge',
+                'outro',
+                'hook',
+                'refrain',
+                'coda',
+                'solo',
+                'interlude',
+                'ending',
+                'breakdown',
+                'tag'
+            ];
+            return text.split(/\r?\n/).map(line => {
+                const trimmed = line.trim();
+                if (!trimmed) return line;
+                const match = trimmed.match(/^[\*\s\-_=~`]*[\(\[\{]?\s*([^\]\)\}]+?)\s*[\)\]\}]?[\*\s\-_=~`]*:?$/);
+                if (match) {
+                    const label = match[1].trim();
+                    const normalized = label.toLowerCase().replace(/[^a-z]/g, '');
+                    if (sectionKeywords.some(k => normalized.startsWith(k))) {
+                        const formatted = label
+                            .replace(/\s+/g, ' ')
+                            .replace(/(^|\s)\S/g, c => c.toUpperCase());
+                        return `[${formatted}]`;
+                    }
+                }
+                return line;
+            }).join('\n');
         },
 
         getSongState() {
@@ -378,7 +417,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const lyrics = lyricLines.join('\n');
             const chords = chordLines.join('\n');
 
-            this.currentSong.lyrics = lyrics;
+            this.currentSong.lyrics = this.normalizeSectionLabels(lyrics);
             this.currentSong.chords = chords;
             this.currentSong.lastEditedAt = new Date().toISOString();
 
@@ -411,11 +450,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
             document.getElementById('song-title-card').textContent = this.currentSong.title;
             this.fontSizeDisplay.textContent = `${this.fontSize}px`;
-            
+
             // Update tempo input
             if (this.tempoInput) {
                 this.tempoInput.value = this.currentSong.tempo;
             }
+
+            this.currentSong.lyrics = this.normalizeSectionLabels(this.currentSong.lyrics || '');
 
             this.renderLyrics();
 
@@ -423,6 +464,7 @@ document.addEventListener('DOMContentLoaded', () => {
             this.undoStack = [this.getSongState()];
             this.redoStack = [];
             this.lastSnapshotTime = Date.now();
+            this.saveCurrentSong(true);
         },
 
         renderLyrics() {

--- a/editor/songs.js
+++ b/editor/songs.js
@@ -1,8 +1,45 @@
 // Enhanced song data structure with metadata
+const defaultSections = "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]";
+
+const normalizeSectionLabels = (text = '') => {
+    const sectionKeywords = [
+        'intro',
+        'verse',
+        'prechorus',
+        'chorus',
+        'bridge',
+        'outro',
+        'hook',
+        'refrain',
+        'coda',
+        'solo',
+        'interlude',
+        'ending',
+        'breakdown',
+        'tag'
+    ];
+    return text.split(/\r?\n/).map(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return line;
+        const match = trimmed.match(/^[\*\s\-_=~`]*[\(\[\{]?\s*([^\]\)\}]+?)\s*[\)\]\}]?[\*\s\-_=~`]*:?$/);
+        if (match) {
+            const label = match[1].trim();
+            const normalized = label.toLowerCase().replace(/[^a-z]/g, '');
+            if (sectionKeywords.some(k => normalized.startsWith(k))) {
+                const formatted = label
+                    .replace(/\s+/g, ' ')
+                    .replace(/(^|\s)\S/g, c => c.toUpperCase());
+                return `[${formatted}]`;
+            }
+        }
+        return line;
+    }).join('\n');
+};
+
 const createSong = (title, lyrics = '', chords = '') => ({
     id: Date.now().toString(),
     title,
-    lyrics,
+    lyrics: lyrics.trim() ? normalizeSectionLabels(lyrics) : defaultSections,
     chords,
     // New metadata fields
     key: '',

--- a/script.js
+++ b/script.js
@@ -93,6 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
     songList: document.getElementById('song-list'),
     songs: [],
     currentSongId: null,
+    defaultSections: "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]",
 
     init() {
       // Load mammoth for DOCX processing
@@ -118,7 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return {
         id: song.id || Date.now().toString(),
         title: song.title || 'Untitled',
-        lyrics: song.lyrics || '',
+        lyrics: this.normalizeSectionLabels(song.lyrics || ''),
         chords: song.chords || '',
         key: song.key || '',
         tempo: song.tempo || 120,
@@ -131,10 +132,13 @@ document.addEventListener('DOMContentLoaded', () => {
     },
 
     createSong(title, lyrics = '', chords = '') {
+      const normalizedLyrics = lyrics.trim()
+        ? this.normalizeSectionLabels(lyrics)
+        : this.defaultSections;
       return {
         id: Date.now().toString(),
         title,
-        lyrics,
+        lyrics: normalizedLyrics,
         chords,
         key: '',
         tempo: 120,
@@ -158,6 +162,41 @@ document.addEventListener('DOMContentLoaded', () => {
         .trim()
         .replace(/([a-z])([A-Z])/g, '$1 $2')
         .replace(/\w\S*/g, w => w[0].toUpperCase() + w.slice(1).toLowerCase());
+    },
+
+    normalizeSectionLabels(text = '') {
+      const sectionKeywords = [
+        'intro',
+        'verse',
+        'prechorus',
+        'chorus',
+        'bridge',
+        'outro',
+        'hook',
+        'refrain',
+        'coda',
+        'solo',
+        'interlude',
+        'ending',
+        'breakdown',
+        'tag'
+      ];
+      return text.split(/\r?\n/).map(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return line;
+        const match = trimmed.match(/^[\*\s\-_=~`]*[\(\[\{]?\s*([^\]\)\}]+?)\s*[\)\]\}]?[\*\s\-_=~`]*:?$/);
+        if (match) {
+          const label = match[1].trim();
+          const normalized = label.toLowerCase().replace(/[^a-z]/g, '');
+          if (sectionKeywords.some(k => normalized.startsWith(k))) {
+            const formatted = label
+              .replace(/\s+/g, ' ')
+              .replace(/(^|\s)\S/g, c => c.toUpperCase());
+            return `[${formatted}]`;
+          }
+        }
+        return line;
+      }).join('\n');
     },
 
     formatTimeAgo(dateString) {


### PR DESCRIPTION
## Summary
- Normalize section headers to bracket format when importing or saving songs
- Preload new songs with common sections like Intro, Verse, and Chorus
- Ensure editor saves and displays normalized section labels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689526cc7bec832aad1b2ddd550fc053