### PR TITLE
Refactor editor controls layout

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -64,9 +64,6 @@
     margin-right: 0.5rem;
 }
 
-.editor-control-group.center-controls {
-    padding: 0.5rem 1rem;
-}
 
 .song-title-card {
     position: fixed;

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -104,37 +104,27 @@
                             <i class="fas fa-guitar"></i> Toggle Chords
                         </button>
                         <button class="dropdown-item" id="toggle-read-only-btn">
-                            <i class="fas fa-lock"></i> Performance Mode 
+                            <i class="fas fa-lock"></i> Performance Mode
                         </button>
                         <button class="dropdown-item" id="save-song-btn">
                             <i class="fas fa-save"></i> Save Song
                         </button>
+                        <button class="dropdown-item" id="undo-btn">
+                            <i class="fas fa-undo"></i> Undo
+                        </button>
+                        <button class="dropdown-item" id="redo-btn">
+                            <i class="fas fa-redo"></i> Redo
+                        </button>
+                        <button class="dropdown-item" id="copy-lyrics-btn">
+                            <i class="fas fa-copy"></i> Copy Options
+                        </button>
+                        <button class="dropdown-item" id="metadata-toggle-btn">
+                            <i class="fas fa-info-circle"></i> Song Info & Metadata
+                        </button>
                     </div>
                 </div>
             </div>
-            
-            <div class="editor-control-group center-controls">
-                <button id="decrease-font-btn" class="icon-btn" title="Decrease Font Size">
-                    <i class="fas fa-minus"></i>
-                </button>
-                <span id="font-size-display"></span>
-                <button id="increase-font-btn" class="icon-btn" title="Increase Font Size">
-                    <i class="fas fa-plus"></i>
-                </button>
-            </div>
             <div class="editor-control-group right-controls">
-                 <button id="undo-btn" class="icon-btn" title="Undo">
-                     <i class="fas fa-undo"></i>
-                </button>
-                 <button id="redo-btn" class="icon-btn" title="Redo">
-                     <i class="fas fa-redo"></i>
-                </button>
-                 <button id="copy-lyrics-btn" class="icon-btn copy-lyrics-btn" title="Copy Options">
-                     <i class="fas fa-copy"></i>
-                </button>
-                <button id="metadata-toggle-btn" class="icon-btn" title="Song Info & Metadata">
-                    <i class="fas fa-info-circle"></i>
-                </button>
                 <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme">
                     <i class="fas fa-adjust"></i>
                 </button>
@@ -155,6 +145,15 @@
         </div>
 
         <div class="editor-footer">
+            <div class="footer-controls">
+                <button id="decrease-font-btn" class="icon-btn" title="Decrease Font Size">
+                    <i class="fas fa-minus"></i>
+                </button>
+                <span id="font-size-display"></span>
+                <button id="increase-font-btn" class="icon-btn" title="Increase Font Size">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </div>
             <div class="footer-controls">
                 <label for="measure-mode-toggle" class="control-label">Measure</label>
                 <label class="switch">
@@ -277,6 +276,7 @@
             // Toggle metadata panel
             metadataToggleBtn?.addEventListener('click', () => {
                 metadataPanel.classList.toggle('open');
+                document.querySelector('.editor-dropdown-menu').classList.remove('visible');
             });
             
             metadataCloseBtn?.addEventListener('click', () => {

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -288,10 +288,19 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             // Enhanced copy functionality
-            this.copyLyricsBtn?.addEventListener('click', () => this.toggleCopyDropdown());
+            this.copyLyricsBtn?.addEventListener('click', () => {
+                this.toggleCopyDropdown();
+                document.querySelector('.editor-dropdown-menu').classList.remove('visible');
+            });
 
-            this.undoBtn?.addEventListener('click', () => this.undo());
-            this.redoBtn?.addEventListener('click', () => this.redo());
+            this.undoBtn?.addEventListener('click', () => {
+                this.undo();
+                document.querySelector('.editor-dropdown-menu').classList.remove('visible');
+            });
+            this.redoBtn?.addEventListener('click', () => {
+                this.redo();
+                document.querySelector('.editor-dropdown-menu').classList.remove('visible');
+            });
             
             // Close dropdown when clicking outside
             document.addEventListener('click', (e) => {
@@ -357,7 +366,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 
                 // Position dropdown relative to copy button
                 dropdown.addEventListener('click', (e) => this.handleCopySelection(e));
-                this.copyLyricsBtn.parentNode.appendChild(dropdown);
+                document.body.appendChild(dropdown);
                 this.copyDropdown = dropdown;
             }
         },
@@ -458,6 +467,16 @@ document.addEventListener('DOMContentLoaded', () => {
 
             this.currentSong.lyrics = this.normalizeSectionLabels(this.currentSong.lyrics || '');
 
+            const linesNoTitle = this.currentSong.lyrics.split('\n');
+            const normalizedTitle = (this.currentSong.title || '').trim().toLowerCase();
+            if (linesNoTitle.length && linesNoTitle[0].trim().toLowerCase() === normalizedTitle) {
+                linesNoTitle.shift();
+                if (linesNoTitle[0]?.trim() === '') {
+                    linesNoTitle.shift();
+                }
+                this.currentSong.lyrics = linesNoTitle.join('\n');
+            }
+
             this.renderLyrics();
 
             // Initialize undo/redo stacks for this song
@@ -473,8 +492,19 @@ document.addEventListener('DOMContentLoaded', () => {
             const lyrics = this.currentSong.lyrics || '';
             const chords = this.currentSong.chords || '';
 
-            const lyricLines = lyrics.split('\n');
-            const chordLines = chords.split('\n');
+            let lyricLines = lyrics.split('\n');
+            let chordLines = chords.split('\n');
+
+            const normalizedTitle = (this.currentSong.title || '').trim().toLowerCase();
+            if (lyricLines.length && lyricLines[0].trim().toLowerCase() === normalizedTitle) {
+                lyricLines.shift();
+                if (lyricLines[0]?.trim() === '') {
+                    lyricLines.shift();
+                }
+                if (chordLines.length) {
+                    chordLines.shift();
+                }
+            }
 
             this.lyricsDisplay.innerHTML = '';
             this.syllableGutter.innerHTML = '';


### PR DESCRIPTION
## Summary
- Move font size controls to the editor footer
- Simplify editor header so only theme toggle and exit buttons remain visible
- Remove duplicate title line from lyrics content before rendering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68952b0bc5ec832abaeb0d1acabcadd8