### PR TITLE
Align syllable gutter with lyrics and fix dropdown overlay

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -213,6 +213,17 @@
     user-select: none;
     border-right: 1px solid var(--border-light);
 }
+.gutter-chord-line {
+    line-height: 1.2;
+    height: 1.2em;
+}
+.gutter-lyric-line {
+    line-height: 1.6;
+    margin-bottom: 0.5em;
+}
+.gutter-section-label {
+    margin-bottom: 0.5em;
+}
 #lyrics-display {
     flex-grow: 1;
     padding: 2rem;
@@ -280,17 +291,18 @@
 .editor-dropdown {
     position: relative;
     display: inline-block;
+    z-index: 2000;
 }
 
 .editor-dropdown-menu {
     position: absolute;
     top: 100%;
-    left: 10;
+    left: 0;
     background: var(--bg-secondary);
     border: 1px solid var(--border);
     border-radius: var(--border-radius-base);
     box-shadow: var(--shadow-lg);
-    z-index: 10000;
+    z-index: 2001;
     min-width: 180px;
     opacity: 0;
     visibility: hidden;

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -129,6 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
         minFontSize: 12,
         maxFontSize: 72,
         fontSizeStep: 1,
+        syllableScale: 0.7,
         perSongFontSizes: JSON.parse(localStorage.getItem('perSongFontSizes') || '{}'),
         isReadOnly: false,
         isChordsVisible: true,
@@ -583,6 +584,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     content.className = 'section-content';
                     section.appendChild(content);
                     this.lyricsDisplay.appendChild(section);
+                    const gutterLine = document.createElement('div');
+                    gutterLine.className = 'gutter-section-label';
+                    this.syllableGutter.appendChild(gutterLine);
                     currentSectionContent = content;
                     continue;
                 }
@@ -620,6 +624,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
             this.lyricsDisplay.style.fontSize = `${this.fontSize}px`;
+            this.syllableGutter.style.fontSize = `${this.fontSize * this.syllableScale}px`;
             this.updateReadOnlyState();
             this.updateChordsVisibility();
         },
@@ -657,22 +662,50 @@ document.addEventListener('DOMContentLoaded', () => {
             lineGroup.appendChild(lyricElement);
 
             container.appendChild(lineGroup);
+            const chordPlaceholder = document.createElement('div');
+            chordPlaceholder.className = 'gutter-chord-line';
+            if (!this.isChordsVisible) {
+                chordPlaceholder.style.display = 'none';
+            }
+            this.syllableGutter.appendChild(chordPlaceholder);
 
             const gutterLine = document.createElement('div');
+            gutterLine.className = 'gutter-lyric-line';
             gutterLine.textContent = syllableCount;
             this.syllableGutter.appendChild(gutterLine);
         },
 
         updateSyllableCount() {
-            const lyricElements = this.lyricsDisplay.querySelectorAll('.lyrics-line:not(.section-label)');
             this.syllableGutter.innerHTML = '';
-            lyricElements.forEach(line => {
-                const text = line.textContent;
+            const processLineGroup = (group) => {
+                const chordPlaceholder = document.createElement('div');
+                chordPlaceholder.className = 'gutter-chord-line';
+                if (!this.isChordsVisible) {
+                    chordPlaceholder.style.display = 'none';
+                }
+                this.syllableGutter.appendChild(chordPlaceholder);
+
+                const lyricEl = group.querySelector('.lyrics-line');
+                const text = lyricEl.textContent;
                 const words = text.split(/\s+/).filter(w => w.length > 0);
                 const count = words.reduce((sum, word) => sum + this.syllableCount(word), 0);
                 const gutterLine = document.createElement('div');
+                gutterLine.className = 'gutter-lyric-line';
                 gutterLine.textContent = count;
                 this.syllableGutter.appendChild(gutterLine);
+            };
+
+            const children = Array.from(this.lyricsDisplay.children);
+            children.forEach(child => {
+                if (child.classList.contains('section')) {
+                    const placeholder = document.createElement('div');
+                    placeholder.className = 'gutter-section-label';
+                    this.syllableGutter.appendChild(placeholder);
+                    const inner = child.querySelector('.section-content');
+                    Array.from(inner.children).forEach(processLineGroup);
+                } else if (child.classList.contains('lyrics-line-group')) {
+                    processLineGroup(child);
+                }
             });
         },
 
@@ -767,6 +800,7 @@ document.addEventListener('DOMContentLoaded', () => {
             this.perSongFontSizes[this.currentSong.id] = this.fontSize;
             localStorage.setItem('perSongFontSizes', JSON.stringify(this.perSongFontSizes));
             this.lyricsDisplay.style.fontSize = `${this.fontSize}px`;
+            this.syllableGutter.style.fontSize = `${this.fontSize * this.syllableScale}px`;
             this.fontSizeDisplay.textContent = `${this.fontSize}px`;
         },
 
@@ -813,6 +847,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const chordLines = this.lyricsDisplay.querySelectorAll('.chord-line');
             chordLines.forEach(line => {
                 line.classList.toggle('hidden', !this.isChordsVisible);
+            });
+            const chordGutterLines = this.syllableGutter.querySelectorAll('.gutter-chord-line');
+            chordGutterLines.forEach(line => {
+                line.style.display = this.isChordsVisible ? 'block' : 'none';
             });
             const icon = this.toggleChordsBtn?.querySelector('i');
             if (icon) {


### PR DESCRIPTION
## Summary
- Ensure syllable counts track lyric lines by skipping chords and section labels and scaling with font size
- Hide gutter placeholders when chords are toggled off
- Correct dropdown menu layering and positioning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689550776bd4832aa1a9cd08799b2d70