### PR TITLE
Add AI context menu and OpenRouter integration

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -293,6 +293,7 @@
     z-index: 2000;
 }
 
+
 .editor-dropdown-menu {
     position: absolute;
     top: 100%;
@@ -301,22 +302,13 @@
     border: 1px solid var(--border);
     border-radius: var(--border-radius-base);
     box-shadow: var(--shadow-lg);
-    z-index: 2001;
+    z-index: 99999;
     min-width: 180px;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-10px);
-    transition: all 0.2s ease;
-    background: var(--bg-tertiary);
-    padding: 0.5rem 0;
     transform: translateY(10px);
-}
-
-.editor-dropdown:hover .editor-dropdown-menu,
-.editor-dropdown:focus-within .editor-dropdown-menu {
-    opacity: 1;
-    visibility: visible;
-    transform: translateY(0);
+    transition: all 0.2s ease;
+    padding: 0.5rem 0;
 }
 
 .editor-dropdown-menu.visible {
@@ -330,12 +322,12 @@
     align-items: center;
     gap: 0.75rem;
     width: 100%;
-    padding: 0.6rem 1rem;
+    padding: 0.75rem 1.25rem;
     background: transparent;
     border: none;
     color: var(--text-primary);
     text-align: left;
-    font-size: 0.95rem;
+    font-size: 1rem;
     cursor: pointer;
 }
 
@@ -350,6 +342,18 @@
 
 .dropdown-item .switch {
     margin-left: auto;
+}
+
+.close-dropdown-btn {
+    font-weight: bold;
+    justify-content: center;
+}
+
+@media (max-width: 600px) {
+    .editor-dropdown-menu .dropdown-item {
+        padding: 1rem 1.5rem;
+        font-size: 1.1rem;
+    }
 }
 
 /* ========================================
@@ -646,4 +650,90 @@ toolbar {
     min-width: 160px;
     left: 50%;
   }
+}
+
+/* Floating AI context menu */
+.ai-context-menu {
+    position: absolute;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-base);
+    box-shadow: var(--shadow-lg);
+    padding: 0.25rem;
+    display: none;
+    z-index: 99999;
+    gap: 0.25rem;
+}
+
+.ai-context-menu button {
+    background: var(--accent-primary);
+    border: none;
+    color: #fff;
+    padding: 0.35rem 0.5rem;
+    border-radius: var(--border-radius-base);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.ai-context-menu button:active {
+    transform: scale(0.97);
+}
+
+@media (max-width: 600px) {
+    .ai-context-menu {
+        padding: 0.5rem;
+    }
+    .ai-context-menu button {
+        padding: 0.6rem 0.75rem;
+        font-size: 1rem;
+    }
+}
+
+/* AI Settings panel */
+.ai-settings-panel {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-base);
+    box-shadow: var(--shadow-lg);
+    z-index: 99999;
+    padding: 1rem;
+    width: 300px;
+    max-height: 80vh;
+    overflow-y: auto;
+    display: none;
+}
+
+.ai-settings-panel h3 {
+    margin-top: 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.ai-settings-panel .model-list {
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-base);
+    margin-top: 0.5rem;
+}
+
+.ai-settings-panel .model-item {
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+}
+
+.ai-settings-panel .model-item:hover,
+.ai-settings-panel .model-item.selected {
+    background: var(--bg-hover);
+}
+
+@media (max-width: 600px) {
+    .ai-settings-panel {
+        width: 90%;
+    }
 }

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -137,10 +137,38 @@
                         <button class="dropdown-item" id="metadata-toggle-btn">
                             <i class="fas fa-info-circle"></i> Song Info & Metadata
                         </button>
+                        <button class="dropdown-item close-dropdown-btn" id="editor-menu-close-btn">
+                            <i class="fas fa-times"></i> Close
+                        </button>
                     </div>
                 </div>
             </div>
             <div class="editor-control-group right-controls">
+                <div class="editor-dropdown ai-tools-dropdown">
+                    <button id="ai-tools-btn" class="icon-btn" title="AI Tools">
+                        <i class="fas fa-robot"></i>
+                    </button>
+                    <div class="editor-dropdown-menu ai-tools-menu" id="ai-tools-menu">
+                        <button class="dropdown-item tool-option" data-prompt="Generate First Draft">
+                            <i class="fas fa-magic"></i> Generate First Draft
+                        </button>
+                        <button class="dropdown-item tool-option" data-prompt="Polish Lyrics">
+                            <i class="fas fa-brush"></i> Polish Lyrics
+                        </button>
+                        <button class="dropdown-item tool-option" data-prompt="Rewrite in Different Style">
+                            <i class="fas fa-pen"></i> Rewrite in Different Style
+                        </button>
+                        <button class="dropdown-item tool-option" data-prompt="Continue Song">
+                            <i class="fas fa-arrow-down"></i> Continue Song
+                        </button>
+                        <button class="dropdown-item" id="ai-settings-btn">
+                            <i class="fas fa-cog"></i> Settings
+                        </button>
+                        <button class="dropdown-item close-dropdown-btn" id="ai-tools-close-btn">
+                            <i class="fas fa-times"></i> Close
+                        </button>
+                    </div>
+                </div>
                 <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme">
                     <i class="fas fa-adjust"></i>
                 </button>
@@ -157,6 +185,13 @@
 
             <!-- Enhanced Copy Button with Dropdown -->
 
+        </div>
+
+        <div id="ai-context-menu" class="ai-context-menu">
+            <button data-action="rhyme">🎯 Rhyme</button>
+            <button data-action="reword">🔄 Reword</button>
+            <button data-action="rewrite">✍️ Rewrite</button>
+            <button data-action="continue">💡 Continue</button>
         </div>
 
         <div class="editor-footer">
@@ -257,6 +292,25 @@
         </div>
     </div>
 
+    <div id="ai-settings-panel" class="ai-settings-panel">
+        <h3>
+            AI Settings
+            <button id="ai-settings-close" class="icon-btn" title="Close">
+                <i class="fas fa-times"></i>
+            </button>
+        </h3>
+        <div class="settings-row">
+            <label for="openrouter-api-key">API Key</label>
+            <input type="text" id="openrouter-api-key" placeholder="OpenRouter API Key">
+        </div>
+        <div class="settings-row">
+            <label for="model-search">Model</label>
+            <input type="text" id="model-search" placeholder="Search models...">
+            <div id="model-list" class="model-list"></div>
+        </div>
+        <button id="save-ai-settings" class="dropdown-item" style="width:100%">Save</button>
+    </div>
+
     <script src="../config.js"></script>
     <script src="songs.js"></script>
     <script src="editor.js"></script>
@@ -273,7 +327,6 @@
             // Toggle metadata panel
             metadataToggleBtn?.addEventListener('click', () => {
                 metadataPanel.classList.toggle('open');
-                document.querySelector('.editor-dropdown-menu').classList.remove('visible');
             });
             
             metadataCloseBtn?.addEventListener('click', () => {

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -117,6 +117,18 @@ document.addEventListener('DOMContentLoaded', () => {
         redoBtn: document.getElementById('redo-btn'),
         editorMenuBtn: document.getElementById('editor-menu-btn'),
         editorDropdownMenu: document.querySelector('.editor-dropdown-menu'),
+        editorDropdownCloseBtn: document.getElementById('editor-menu-close-btn'),
+        aiContextMenu: document.getElementById('ai-context-menu'),
+        aiToolsBtn: document.getElementById('ai-tools-btn'),
+        aiToolsMenu: document.getElementById('ai-tools-menu'),
+        aiToolsCloseBtn: document.getElementById('ai-tools-close-btn'),
+        aiSettingsBtn: document.getElementById('ai-settings-btn'),
+        aiSettingsPanel: document.getElementById('ai-settings-panel'),
+        aiSettingsClose: document.getElementById('ai-settings-close'),
+        apiKeyInput: document.getElementById('openrouter-api-key'),
+        modelSearchInput: document.getElementById('model-search'),
+        modelList: document.getElementById('model-list'),
+        saveAISettingsBtn: document.getElementById('save-ai-settings'),
         measureModeToggle: document.getElementById('measure-mode-toggle'),
         rhymeModeToggle: document.getElementById('rhyme-mode-toggle'),
 
@@ -138,6 +150,8 @@ document.addEventListener('DOMContentLoaded', () => {
         resizeObserver: null,
         copyDropdown: null,
         hasUnsavedChanges: false, // Track unsaved changes
+        availableModels: [],
+        selectedModel: '',
         undoStack: [],
         redoStack: [],
         lastSnapshotTime: 0,
@@ -152,6 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         init() {
             this.loadData();
+            this.loadAISettings();
             this.setupEventListeners();
             this.loadEditorState();
             this.createCopyDropdown();
@@ -275,55 +290,78 @@ document.addEventListener('DOMContentLoaded', () => {
             this.editorMenuBtn?.addEventListener('click', () => {
                 this.editorDropdownMenu?.classList.toggle('visible');
             });
+            this.editorDropdownCloseBtn?.addEventListener('click', () => {
+                this.editorDropdownMenu?.classList.remove('visible');
+            });
             // Handle dropdown items
             document.getElementById('toggle-chords-btn')?.addEventListener('click', () => {
                 this.toggleChords();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
             document.getElementById('toggle-read-only-btn')?.addEventListener('click', () => {
                 this.toggleReadOnly();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
             document.getElementById('save-song-btn')?.addEventListener('click', () => {
                 this.saveCurrentSong(true);
-                this.editorDropdownMenu?.classList.remove('visible');
             });
 
             // Enhanced copy functionality
             this.copyLyricsBtn?.addEventListener('click', () => {
                 this.toggleCopyDropdown();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
 
             this.undoBtn?.addEventListener('click', () => {
                 this.undo();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
             this.redoBtn?.addEventListener('click', () => {
                 this.redo();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
-
-            // Close dropdown when clicking outside
+            // Close copy dropdown when clicking outside
             document.addEventListener('click', (e) => {
                 if (this.copyDropdown && !this.copyLyricsBtn.contains(e.target) && !this.copyDropdown.contains(e.target)) {
                     this.copyDropdown.classList.remove('visible');
-                }
-                if (this.editorDropdownMenu && !this.editorMenuBtn.contains(e.target) && !this.editorDropdownMenu.contains(e.target)) {
-                    this.editorDropdownMenu.classList.remove('visible');
                 }
             });
 
             this.measureModeToggle?.addEventListener('change', (e) => {
                 this.isMeasureMode = e.target.checked;
                 this.renderLyrics();
-                this.editorDropdownMenu?.classList.remove('visible');
             });
 
             this.rhymeModeToggle?.addEventListener('change', (e) => {
                 this.isRhymeMode = e.target.checked;
                 this.renderLyrics();
-                this.editorDropdownMenu?.classList.remove('visible');
+            });
+
+            // AI Tools dropdown
+            this.aiToolsBtn?.addEventListener('click', () => {
+                this.aiToolsMenu?.classList.toggle('visible');
+            });
+            this.aiToolsCloseBtn?.addEventListener('click', () => {
+                this.aiToolsMenu?.classList.remove('visible');
+            });
+            document.querySelectorAll('.ai-tools-menu .tool-option').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    console.log(btn.dataset.prompt);
+                });
+            });
+            this.aiSettingsBtn?.addEventListener('click', () => {
+                this.openAISettings();
+            });
+            this.aiSettingsClose?.addEventListener('click', () => {
+                this.aiSettingsPanel.style.display = 'none';
+            });
+            this.saveAISettingsBtn?.addEventListener('click', () => this.saveAISettings());
+            this.modelSearchInput?.addEventListener('input', () => this.renderModelList(this.modelSearchInput.value));
+            this.lyricsDisplay?.addEventListener('mouseup', () => this.handleTextSelection());
+            this.lyricsDisplay?.addEventListener('keyup', () => this.handleTextSelection());
+            this.lyricsDisplay?.addEventListener('touchend', () => this.handleTextSelection());
+            document.querySelectorAll('#ai-context-menu button').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const action = btn.dataset.action;
+                    const text = window.getSelection().toString();
+                    this.handleAIAction(action, text);
+                    this.aiContextMenu.style.display = 'none';
+                });
             });
 
             // Metadata input listeners
@@ -388,6 +426,122 @@ document.addEventListener('DOMContentLoaded', () => {
                     }, 100);
                 });
                 this.resizeObserver.observe(this.editorMode);
+            }
+        },
+
+        loadAISettings() {
+            const key = localStorage.getItem('openrouterApiKey') || '';
+            const model = localStorage.getItem('openrouterModel') || '';
+            window.CONFIG = window.CONFIG || {};
+            window.CONFIG.openrouterApiKey = key;
+            window.CONFIG.defaultModel = model;
+            this.selectedModel = model;
+            if (this.apiKeyInput) this.apiKeyInput.value = key;
+        },
+
+        openAISettings() {
+            if (this.aiSettingsPanel) {
+                this.aiSettingsPanel.style.display = 'block';
+                if (!this.availableModels.length) {
+                    this.fetchModels();
+                } else {
+                    this.renderModelList(this.modelSearchInput?.value || '');
+                }
+            }
+        },
+
+        saveAISettings() {
+            const key = this.apiKeyInput?.value.trim() || '';
+            window.CONFIG.openrouterApiKey = key;
+            window.CONFIG.defaultModel = this.selectedModel;
+            localStorage.setItem('openrouterApiKey', key);
+            localStorage.setItem('openrouterModel', this.selectedModel);
+            this.aiSettingsPanel.style.display = 'none';
+        },
+
+        async fetchModels() {
+            try {
+                const res = await fetch('https://openrouter.ai/api/v1/models');
+                const data = await res.json();
+                this.availableModels = data.data || [];
+                this.renderModelList(this.modelSearchInput?.value || '');
+            } catch (err) {
+                console.error('Failed to fetch models', err);
+            }
+        },
+
+        renderModelList(filter = '') {
+            if (!this.modelList) return;
+            const term = filter.toLowerCase();
+            this.modelList.innerHTML = '';
+            this.availableModels
+                .filter(m => m.id.toLowerCase().includes(term))
+                .forEach(m => {
+                    const item = document.createElement('div');
+                    item.className = 'model-item' + (m.id === this.selectedModel ? ' selected' : '');
+                    item.textContent = m.id;
+                    item.addEventListener('click', () => {
+                        this.selectedModel = m.id;
+                        this.renderModelList(term);
+                    });
+                    this.modelList.appendChild(item);
+                });
+        },
+
+        handleTextSelection() {
+            if (!this.aiContextMenu) return;
+            const selection = window.getSelection();
+            if (selection && selection.rangeCount > 0 && !selection.isCollapsed) {
+                const range = selection.getRangeAt(0);
+                const startEl = range.startContainer.parentElement;
+                if (!startEl.closest('.lyrics-line')) {
+                    this.aiContextMenu.style.display = 'none';
+                    return;
+                }
+                const rect = range.getBoundingClientRect();
+                const topOffset = window.innerWidth < 600 ? 20 : 5;
+                this.aiContextMenu.style.top = `${rect.bottom + window.scrollY + topOffset}px`;
+                this.aiContextMenu.style.left = `${rect.left + window.scrollX}px`;
+                this.aiContextMenu.style.display = 'flex';
+            } else {
+                this.aiContextMenu.style.display = 'none';
+            }
+        },
+
+        handleAIAction(action, selectedText) {
+            const prompts = {
+                rhyme: `Find rhymes for: ${selectedText}`,
+                reword: `Suggest alternative wording for: ${selectedText}`,
+                rewrite: `Rewrite this line in a different tone: ${selectedText}`,
+                continue: `Continue the lyrics after: ${selectedText}`
+            };
+            const prompt = prompts[action];
+            if (!window.CONFIG.openrouterApiKey) {
+                console.warn('OpenRouter API key not set');
+                alert('Please set your OpenRouter API key in AI Settings.');
+                return;
+            }
+            console.log(prompt);
+            this.callOpenRouter(prompt);
+        },
+
+        async callOpenRouter(prompt) {
+            try {
+                const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': `Bearer ${window.CONFIG.openrouterApiKey}`
+                    },
+                    body: JSON.stringify({
+                        model: window.CONFIG.defaultModel || '',
+                        messages: [{ role: 'user', content: prompt }]
+                    })
+                });
+                const data = await res.json();
+                console.log('OpenRouter response', data);
+            } catch (err) {
+                console.error('OpenRouter error', err);
             }
         },
 


### PR DESCRIPTION
## Summary
- Keep editor dropdowns persistent with manual close buttons and mobile-friendly styling
- Add floating AI context menu and top-right AI Tools dropdown with settings panel for OpenRouter integration
- Wire up OpenRouter API calls with selectable models and handle AI actions based on selected text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689580997c8c832a9fae363a194eae85