### PR TITLE
Improve mobile editor text size and dropdown behavior

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -135,7 +135,7 @@
 .lyrics-container {
     flex-grow: 1;
     overflow-y: auto;
-    font-size: var(--font-size-lyrics, 1.5rem); /* Base size, slider still works */
+    font-size: var(--font-size-lyrics, 1rem); /* Base size, slider still works */
     padding: var(--padding-lyrics, 2rem);
     line-height: var(--line-height-lyrics, 1.6);
     color: var(--text-primary); /* Lyrics use primary text color */
@@ -382,29 +382,25 @@
     ======================================== */
 .copy-dropdown-menu {
     position: fixed;
-    top: 130px;
-    bottom: auto;
-    left: 75%;
-    right: auto;
-    transform: translateX(-50%) translateY(10px);
+    top: 0;
+    left: 0;
     min-width: 200px;
     background: var(--bg-secondary);
     border: 1px solid var(--border);
     border-radius: var(--border-radius-base);
     box-shadow: var(--shadow-lg);
     z-index: 10000;
-    min-width: 180px;
     opacity: 0;
     visibility: hidden;
-    transform: translateY(-10px);
-    transition: all 0.2s ease;
+    transform: translateX(-50%) translateY(-10px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
     pointer-events: none;
 }
 
 .copy-dropdown-menu.visible {
     opacity: 1;
     visibility: visible;
-    transform: translateY(0);
+    transform: translateX(-50%) translateY(0);
     pointer-events: auto;
 }
 
@@ -557,24 +553,10 @@ toolbar {
   }
 
   .lyrics-container {
-    font-size: 1.3rem; /* Adjusted base font size for lyrics on tablets */
-    padding: 1em 0.8em 1.5em 0.8em !important; 
+    font-size: 1rem; /* Base font size for lyrics on mobile */
+    padding: 1em 0.8em 1.5em 0.8em !important;
     line-height: 1.4 !important; /* Slightly more relaxed line-height for readability */
   }
-  
-  .lyrics-container {
-    flex-grow: 1;
-    overflow-y: auto;
-    font-size: 0.5rem; /* Base size, slider still works */
-    padding: 0.5rem;
-    line-height: 1.6;
-    color: var(--text-primary); /* Lyrics use primary text color */
-    transition: color var(--transition-speed);
-    text-align: left; /* Adjust for better lyric display */
-    display: flex;
-    white-space: pre-wrap; /* Preserve line breaks and spaces */
-    word-break: break-word;
-}
   .scroll-to-top-btn {
     position: fixed;
     bottom: 7em;

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -137,7 +137,7 @@ document.addEventListener('DOMContentLoaded', () => {
         songs: [],
         editorSongs: [],
         currentEditorSongIndex: -1,
-        fontSize: 32,
+        fontSize: 16,
         minFontSize: 12,
         maxFontSize: 72,
         fontSizeStep: 1,
@@ -325,7 +325,10 @@ document.addEventListener('DOMContentLoaded', () => {
             this.lyricsDisplay?.addEventListener('click', (e) => this.handleLyricsClick(e));
             this.lyricsDisplay?.addEventListener('keydown', (e) => this.handleLyricsKeydown(e));
             this.scrollToTopBtn?.addEventListener('click', () => this.scrollToTop());
-            this.editorMenuBtn?.addEventListener('click', () => {
+            this.editorMenuBtn?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.aiToolsMenu?.classList.remove('visible');
+                this.copyDropdown?.classList.remove('visible');
                 this.editorDropdownMenu?.classList.add('visible');
             });
             this.editorDropdownCloseBtn?.addEventListener('click', () => {
@@ -348,7 +351,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             // Enhanced copy functionality
-            this.copyLyricsBtn?.addEventListener('click', () => {
+            this.copyLyricsBtn?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.editorDropdownMenu?.classList.remove('visible');
+                this.aiToolsMenu?.classList.remove('visible');
                 this.toggleCopyDropdown();
             });
 
@@ -358,10 +364,25 @@ document.addEventListener('DOMContentLoaded', () => {
             this.redoBtn?.addEventListener('click', () => {
                 this.redo();
             });
-            // Close copy dropdown when clicking outside
+            // Close dropdowns when clicking outside
             document.addEventListener('click', (e) => {
                 if (this.copyDropdown && !this.copyLyricsBtn.contains(e.target) && !this.copyDropdown.contains(e.target)) {
                     this.copyDropdown.classList.remove('visible');
+                }
+                if (this.editorDropdownMenu?.classList.contains('visible') &&
+                    !this.editorMenuBtn.contains(e.target) &&
+                    !this.editorDropdownMenu.contains(e.target)) {
+                    this.editorDropdownMenu.classList.remove('visible');
+                }
+                if (this.aiToolsMenu?.classList.contains('visible') &&
+                    !this.aiToolsBtn.contains(e.target) &&
+                    !this.aiToolsMenu.contains(e.target)) {
+                    this.aiToolsMenu.classList.remove('visible');
+                }
+            });
+            window.addEventListener('resize', () => {
+                if (this.copyDropdown?.classList.contains('visible')) {
+                    this.positionCopyDropdown();
                 }
             });
 
@@ -376,7 +397,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             // AI Tools dropdown
-            this.aiToolsBtn?.addEventListener('click', () => {
+            this.aiToolsBtn?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.editorDropdownMenu?.classList.remove('visible');
+                this.copyDropdown?.classList.remove('visible');
                 this.aiToolsMenu?.classList.add('visible');
             });
             this.aiToolsCloseBtn?.addEventListener('click', () => {
@@ -430,6 +454,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     e.preventDefault();
                     this.redo();
                 }
+                if (e.key === 'Escape') {
+                    this.editorDropdownMenu?.classList.remove('visible');
+                    this.aiToolsMenu?.classList.remove('visible');
+                    this.copyDropdown?.classList.remove('visible');
+                }
             });
         },
 
@@ -456,10 +485,18 @@ document.addEventListener('DOMContentLoaded', () => {
                     </button>
                 `;
                 
-                // Position dropdown relative to copy button
                 dropdown.addEventListener('click', (e) => this.handleCopySelection(e));
                 document.body.appendChild(dropdown);
                 this.copyDropdown = dropdown;
+                this.positionCopyDropdown();
+            }
+        },
+
+        positionCopyDropdown() {
+            if (this.copyDropdown && this.copyLyricsBtn) {
+                const rect = this.copyLyricsBtn.getBoundingClientRect();
+                this.copyDropdown.style.top = `${rect.bottom + 8}px`;
+                this.copyDropdown.style.left = `${rect.left + rect.width / 2}px`;
             }
         },
 
@@ -730,7 +767,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!this.currentSong.createdAt) this.currentSong.createdAt = new Date().toISOString();
             if (!this.currentSong.lastEditedAt) this.currentSong.lastEditedAt = new Date().toISOString();
 
-            this.fontSize = this.perSongFontSizes[this.currentSong.id] || 32;
+            this.fontSize = this.perSongFontSizes[this.currentSong.id] || 16;
 
             document.getElementById('song-title-card').textContent = this.currentSong.title;
             this.fontSizeDisplay.textContent = `${this.fontSize}px`;
@@ -1116,6 +1153,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
         toggleCopyDropdown() {
             if (this.copyDropdown) {
+                if (!this.copyDropdown.classList.contains('visible')) {
+                    this.positionCopyDropdown();
+                }
                 this.copyDropdown.classList.toggle('visible');
             }
         },

--- a/style.css
+++ b/style.css
@@ -378,7 +378,7 @@ img, video, iframe {
     }
 
     .lyrics-container {
-        font-size: 1.3rem; /* Adjusted base font size for lyrics on tablets */
+        font-size: 1rem; /* Base font size for lyrics on mobile */
         padding: 1em 0.8em 1.5em 0.8em !important; /* Adjusted padding for lyrics */
         line-height: 1.4 !important; /* Slightly more relaxed line-height for readability */
     }
@@ -592,7 +592,7 @@ img, video, iframe {
 .lyrics-container {
     flex-grow: 1;
     overflow-y: auto;
-    font-size: 1.5rem; /* Base size, slider still works */
+    font-size: 1rem; /* Base size, slider still works */
     padding: 2rem;
     text-align: center;
     line-height: 1.6;
@@ -1206,7 +1206,7 @@ html, body {
   /* Reduce lyric container padding for tighter view */
   .lyrics-container {
     padding: 0.6em 0.3em 1em 0.3em !important;
-    font-size: 1.3rem !important;
+    font-size: 1rem !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- Set editor font size default to 16px for better mobile readability
- Fix dropdown menus: close on outside tap, only one open, and copy menu positions under its button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68959e90c058832aa8bf361e433d0ccd