### PR TITLE
Add undo/redo controls and clipboard import with search highlighting

### DIFF
--- a/editor/editor.html
+++ b/editor/editor.html
@@ -124,12 +124,6 @@
                         <button class="dropdown-item" id="regenre-btn">
                             <i class="fas fa-random"></i> Re-Genre (AI Style Flip)
                         </button>
-                        <button class="dropdown-item" id="undo-btn">
-                            <i class="fas fa-undo"></i> Undo
-                        </button>
-                        <button class="dropdown-item" id="redo-btn">
-                            <i class="fas fa-redo"></i> Redo
-                        </button>
                         <button class="dropdown-item" id="copy-lyrics-btn">
                             <i class="fas fa-copy"></i> Copy Options
                         </button>
@@ -157,6 +151,12 @@
                         </button>
                     </div>
                 </div>
+                <button id="undo-btn" class="icon-btn" title="Undo">
+                    <i class="fas fa-undo"></i>
+                </button>
+                <button id="redo-btn" class="icon-btn" title="Redo">
+                    <i class="fas fa-redo"></i>
+                </button>
             </div>
             <div class="editor-control-group right-controls">
                 <div class="editor-dropdown ai-tools-dropdown">
@@ -350,7 +350,7 @@
             
             // Manual save button
             saveBtn?.addEventListener('click', () => {
-                if (window.app && window.app.saveCurrentSong) {
+                if (window.app?.saveCurrentSong) {
                     window.app.saveCurrentSong(true);
                 }
             });

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -331,6 +331,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.copyDropdown?.classList.remove('visible');
                 this.editorDropdownMenu?.classList.add('visible');
             });
+            this.editorMenuBtn?.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.aiToolsMenu?.classList.remove('visible');
+                    this.copyDropdown?.classList.remove('visible');
+                    this.editorDropdownMenu?.classList.add('visible');
+                }
+            });
             this.editorDropdownCloseBtn?.addEventListener('click', () => {
                 this.editorDropdownMenu?.classList.remove('visible');
             });
@@ -368,12 +376,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.aiToolsMenu?.classList.remove('visible');
                 this.toggleCopyDropdown();
             });
+            this.copyLyricsBtn?.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.editorDropdownMenu?.classList.remove('visible');
+                    this.aiToolsMenu?.classList.remove('visible');
+                    this.toggleCopyDropdown();
+                }
+            });
 
             this.undoBtn?.addEventListener('click', () => {
                 this.undo();
             });
             this.redoBtn?.addEventListener('click', () => {
                 this.redo();
+            });
+            document.getElementById('export-single-song')?.addEventListener('click', () => {
+                const content = ClipboardManager.formatSongForExport(this.currentSong, true);
+                const blob = new Blob([content], { type: 'text/plain' });
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = `${this.currentSong.title.replace(/\s+/g, '_')}.txt`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
             });
             // Close dropdowns when clicking outside
             document.addEventListener('click', (e) => {
@@ -413,6 +439,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.editorDropdownMenu?.classList.remove('visible');
                 this.copyDropdown?.classList.remove('visible');
                 this.aiToolsMenu?.classList.add('visible');
+            });
+            this.aiToolsBtn?.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this.editorDropdownMenu?.classList.remove('visible');
+                    this.copyDropdown?.classList.remove('visible');
+                    this.aiToolsMenu?.classList.add('visible');
+                }
             });
             this.aiToolsCloseBtn?.addEventListener('click', () => {
                 this.aiToolsMenu?.classList.remove('visible');
@@ -1272,4 +1306,5 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     app.init();
+    window.app = app;
 });

--- a/script.js
+++ b/script.js
@@ -212,6 +212,12 @@ document.addEventListener('DOMContentLoaded', () => {
       return date.toLocaleDateString();
     },
 
+    highlightMatch(text, query) {
+      if (!query) return text;
+      const regex = new RegExp(`(${query})`, 'ig');
+      return text.replace(regex, '<mark>$1</mark>');
+    },
+
     renderSongs(searchQuery = "") {
       this.songList.innerHTML = '';
 
@@ -241,10 +247,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (song.timeSignature && song.timeSignature !== '4/4') metadata.push(song.timeSignature);
         
         const lastEdited = this.formatTimeAgo(song.lastEditedAt);
-        
+
         item.innerHTML = `
           <div class="song-info">
-            <span class="song-title">${song.title}</span>
+            <span class="song-title">${this.highlightMatch(song.title, searchQuery)}</span>
             ${metadata.length > 0 ? `<div class="song-metadata">${metadata.join(' • ')}</div>` : ''}
             <div class="song-details">
               ${song.tags?.length > 0 ? `<span class="song-tags">${song.tags.join(', ')}</span>` : ''}
@@ -306,6 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <div class="toolbar-buttons-group">
           <button id="add-song-btn" class="btn" title="Add Song"><i class="fas fa-plus"></i></button>
           <button id="export-library-btn" class="btn" title="Export Library"><i class="fas fa-download"></i></button>
+          <button id="import-clipboard-btn" class="btn" title="Paste Song"><i class="fas fa-paste"></i></button>
           <button id="delete-all-songs-btn" class="btn danger" title="Delete All Songs"><i class="fas fa-trash"></i></button>
           <label for="song-upload-input" class="btn" title="Upload Files"><i class="fas fa-upload"></i></label>
         </div>
@@ -314,6 +321,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
       document.getElementById('add-song-btn')?.addEventListener('click', () => this.createNewSong());
       document.getElementById('export-library-btn')?.addEventListener('click', () => this.exportLibrary());
+      document.getElementById('import-clipboard-btn')?.addEventListener('click', async () => {
+        const text = await navigator.clipboard.readText();
+        if (text.trim()) {
+          const title = prompt("Title for pasted song?", "New Song");
+          if (title) {
+            const newSong = this.createSong(title, text);
+            this.songs.push(newSong);
+            this.saveSongs();
+            this.renderSongs();
+          }
+        }
+      });
       document.getElementById('delete-all-songs-btn')?.addEventListener('click', () => this.confirmDeleteAll());
       document.getElementById('song-search-input')?.addEventListener('input', (e) => {
         const query = e.target.value.toLowerCase();

--- a/style.css
+++ b/style.css
@@ -128,6 +128,12 @@ img, video, iframe {
     box-sizing: border-box;
 }
 
+mark {
+    background-color: var(--accent-glow, yellow);
+    padding: 0 2px;
+    border-radius: 3px;
+}
+
 /* Specific adjustments for elements that might cause overflow */
 .page-content,
 .toolbar, {


### PR DESCRIPTION
## Summary
- Expose editor app globally and make save button resilient
- Add visible undo/redo buttons, keyboard-friendly menus, and single-song export
- Highlight search matches, style `<mark>`, and allow song import from clipboard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895b00409ec832abb843630df5d57dc