### PR TITLE
Fix modal layering and mobile AI menu

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -689,17 +689,35 @@ toolbar {
     cursor: pointer;
 }
 
+.ai-context-menu .ai-menu-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    margin-left: auto;
+    padding: 0.25rem;
+    cursor: pointer;
+}
+
+.ai-context-menu .ai-menu-close:hover {
+    color: var(--accent-primary);
+}
+
 .ai-context-menu button:active {
     transform: scale(0.97);
 }
 
 @media (max-width: 600px) {
     .ai-context-menu {
-        padding: 0.75rem;
+        flex-direction: column;
+        padding: 0.5rem;
     }
     .ai-context-menu button {
-        padding: 0.75rem 1rem;
-        font-size: 1.1rem;
+        padding: 0.5rem 0.75rem;
+        font-size: 0.95rem;
+    }
+    .ai-context-menu .ai-menu-close {
+        align-self: flex-end;
+        font-size: 1rem;
     }
 }
 

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -126,6 +126,7 @@
             <button data-action="reword">🔄 Reword</button>
             <button data-action="rewrite">✍️ Rewrite</button>
             <button data-action="continue">💡 Continue</button>
+            <button id="ai-menu-close" class="ai-menu-close">✖</button>
         </div>
 
         <div class="editor-footer">
@@ -308,6 +309,7 @@
             // Toggle metadata panel
             metadataToggleBtn?.addEventListener('click', () => {
                 metadataPanel.classList.toggle('open');
+                document.getElementById('editor-modal')?.classList.remove('visible');
             });
             
             metadataCloseBtn?.addEventListener('click', () => {

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -385,13 +385,24 @@ document.addEventListener('DOMContentLoaded', () => {
             this.lyricsDisplay?.addEventListener('touchmove', () => this.cancelLongPress());
             this.lyricsDisplay?.addEventListener('mousedown', (e) => this.startLongPress(e));
             this.lyricsDisplay?.addEventListener('mouseup', () => this.cancelLongPress());
-            document.querySelectorAll('#ai-context-menu button').forEach(btn => {
+            document.querySelectorAll('#ai-context-menu button[data-action]').forEach(btn => {
                 btn.addEventListener('click', () => {
                     const action = btn.dataset.action;
                     const text = window.getSelection().toString();
                     this.handleAIAction(action, text);
                     this.aiContextMenu.style.display = 'none';
                 });
+            });
+            document.getElementById('ai-menu-close')?.addEventListener('click', () => {
+                this.aiContextMenu.style.display = 'none';
+                window.getSelection()?.removeAllRanges();
+            });
+            document.addEventListener('click', (e) => {
+                if (this.aiContextMenu.style.display === 'flex' &&
+                    !this.aiContextMenu.contains(e.target)) {
+                    this.aiContextMenu.style.display = 'none';
+                    window.getSelection()?.removeAllRanges();
+                }
             });
 
             // Metadata input listeners
@@ -1169,6 +1180,7 @@ document.addEventListener('DOMContentLoaded', () => {
     app.init();
 
     document.getElementById('copy-lyrics-btn')?.addEventListener('click', () => {
+        document.getElementById('editor-modal')?.classList.remove('visible');
         document.getElementById('copy-modal')?.classList.add('visible');
     });
     document.querySelectorAll('.modal-copy-btn')?.forEach(btn => {


### PR DESCRIPTION
## Summary
- Close editor modal before opening copy options or metadata panel so overlays display correctly
- Add closable AI context menu with smaller mobile layout

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6895c0b4e38c832a8bc466818427ba97