### PR TITLE
Refine AI tools modals and restore editor footer

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -415,6 +415,7 @@
 .modal button {
   font-size: 1rem;
 }
+.modal-action-btn,
 .modal-copy-btn {
   background: var(--accent-primary);
   color: white;
@@ -423,6 +424,7 @@
   border-radius: var(--border-radius-base);
   text-align: left;
 }
+.modal-action-btn i,
 .modal-copy-btn i {
   margin-right: 0.5rem;
 }
@@ -506,6 +508,7 @@
     width: calc(100% - 1rem);
     box-shadow: 0 -4px 12px rgba(0,0,0,0.05);
     backdrop-filter: blur(4px);
+    flex-shrink: 0;
 }
 .footer-controls {
     display: flex;
@@ -687,6 +690,10 @@ toolbar {
     border-radius: var(--border-radius-base);
     font-size: 0.85rem;
     cursor: pointer;
+}
+
+.ai-context-menu button i {
+    margin-right: 0.25rem;
 }
 
 .ai-context-menu .ai-menu-close {

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -122,11 +122,11 @@
         </div>
 
         <div id="ai-context-menu" class="ai-context-menu">
-            <button data-action="rhyme">🎯 Rhyme</button>
-            <button data-action="reword">🔄 Reword</button>
-            <button data-action="rewrite">✍️ Rewrite</button>
-            <button data-action="continue">💡 Continue</button>
-            <button id="ai-menu-close" class="ai-menu-close">✖</button>
+            <button data-action="rhyme"><i class="fas fa-bullseye"></i> Rhyme</button>
+            <button data-action="reword"><i class="fas fa-sync"></i> Reword</button>
+            <button data-action="rewrite"><i class="fas fa-pen"></i> Rewrite</button>
+            <button data-action="continue"><i class="fas fa-lightbulb"></i> Continue</button>
+            <button id="ai-menu-close" class="ai-menu-close"><i class="fas fa-times"></i></button>
         </div>
 
         <div class="editor-footer">
@@ -161,8 +161,8 @@
     <div id="editor-modal" class="modal-overlay">
       <div class="modal">
         <h2>Editor Options</h2>
-        <button id="toggle-chords-btn"><i class="fas fa-guitar"></i> Toggle Chords</button>
-        <button id="toggle-read-only-btn"><i class="fas fa-lock"></i> Performance Mode</button>
+        <button id="toggle-chords-btn" class="modal-action-btn"><i class="fas fa-guitar"></i> Toggle Chords</button>
+        <button id="toggle-read-only-btn" class="modal-action-btn"><i class="fas fa-lock"></i> Performance Mode</button>
         <div>
           <label for="edit-mode-select"><i class="fas fa-edit"></i> Edit Mode:</label>
           <select id="edit-mode-select">
@@ -171,13 +171,11 @@
             <option value="chords">Chords</option>
           </select>
         </div>
-        <button id="save-song-btn"><i class="fas fa-save"></i> Save Song</button>
-        <button id="ai-format-btn"><i class="fas fa-broom"></i> Clean Format (AI)</button>
-        <button id="regenre-btn"><i class="fas fa-random"></i> Re-Genre (AI)</button>
-        <button id="copy-lyrics-btn"><i class="fas fa-copy"></i> Copy Options</button>
-        <button id="undo-btn"><i class="fas fa-undo"></i> Undo</button>
-        <button id="redo-btn"><i class="fas fa-redo"></i> Redo</button>
-        <button id="metadata-toggle-btn"><i class="fas fa-info-circle"></i> Song Metadata</button>
+        <button id="save-song-btn" class="modal-action-btn"><i class="fas fa-save"></i> Save Song</button>
+        <button id="copy-lyrics-btn" class="modal-action-btn"><i class="fas fa-copy"></i> Copy Options</button>
+        <button id="undo-btn" class="modal-action-btn"><i class="fas fa-undo"></i> Undo</button>
+        <button id="redo-btn" class="modal-action-btn"><i class="fas fa-redo"></i> Redo</button>
+        <button id="metadata-toggle-btn" class="modal-action-btn"><i class="fas fa-info-circle"></i> Song Metadata</button>
         <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
       </div>
     </div>
@@ -185,11 +183,13 @@
     <div id="ai-tools-modal" class="modal-overlay">
       <div class="modal">
         <h2>AI Tools</h2>
-        <button class="tool-option" data-prompt="Generate First Draft"><i class="fas fa-magic"></i> Generate First Draft</button>
-        <button class="tool-option" data-prompt="Polish Lyrics"><i class="fas fa-brush"></i> Polish Lyrics</button>
-        <button class="tool-option" data-prompt="Rewrite in Different Style"><i class="fas fa-pen"></i> Rewrite in Style</button>
-        <button class="tool-option" data-prompt="Continue Song"><i class="fas fa-arrow-down"></i> Continue Song</button>
-        <button id="ai-settings-btn"><i class="fas fa-cog"></i> Settings</button>
+        <button class="tool-option modal-action-btn" data-prompt="Generate First Draft"><i class="fas fa-magic"></i> Generate First Draft</button>
+        <button class="tool-option modal-action-btn" data-prompt="Polish Lyrics"><i class="fas fa-brush"></i> Polish Lyrics</button>
+        <button class="tool-option modal-action-btn" data-prompt="Rewrite in Different Style"><i class="fas fa-pen"></i> Rewrite in Style</button>
+        <button class="tool-option modal-action-btn" data-prompt="Continue Song"><i class="fas fa-arrow-down"></i> Continue Song</button>
+        <button id="ai-format-btn" class="modal-action-btn"><i class="fas fa-broom"></i> Clean Format (AI)</button>
+        <button id="regenre-btn" class="modal-action-btn"><i class="fas fa-random"></i> Re-Genre (AI)</button>
+        <button id="ai-settings-btn" class="modal-action-btn"><i class="fas fa-cog"></i> Settings</button>
         <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
       </div>
     </div>

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -379,12 +379,16 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             this.saveAISettingsBtn?.addEventListener('click', () => this.saveAISettings());
             this.modelSearchInput?.addEventListener('input', () => this.renderModelList(this.modelSearchInput.value));
-            // Long-press to show AI context menu
+            // Long-press or right-click to show AI context menu
             this.lyricsDisplay?.addEventListener('touchstart', (e) => this.startLongPress(e));
             this.lyricsDisplay?.addEventListener('touchend', () => this.cancelLongPress());
             this.lyricsDisplay?.addEventListener('touchmove', () => this.cancelLongPress());
             this.lyricsDisplay?.addEventListener('mousedown', (e) => this.startLongPress(e));
             this.lyricsDisplay?.addEventListener('mouseup', () => this.cancelLongPress());
+            this.lyricsDisplay?.addEventListener('contextmenu', (e) => {
+                e.preventDefault();
+                this.handleTextSelection();
+            });
             document.querySelectorAll('#ai-context-menu button[data-action]').forEach(btn => {
                 btn.addEventListener('click', () => {
                     const action = btn.dataset.action;


### PR DESCRIPTION
## Summary
- Move Clean Format and Re-Genre actions into the AI Tools modal
- Replace emoji icons with Font Awesome and allow long-press context menu
- Style modals consistently and restore footer font controls

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895dcb53a28832aa54e25d50b87c4a6