### PR TITLE
feat: enhance editor and song list UX

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -424,6 +424,27 @@
 .modal button {
   font-size: 1rem;
 }
+
+.modal label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--text-primary);
+}
+
+.modal-select {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: var(--border-radius-base);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.modal-select:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 2px var(--accent-glow);
+}
 .modal-action-btn,
 .modal-copy-btn {
   background: var(--accent-primary);

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -98,6 +98,15 @@
                 <button id="editor-menu-btn" class="icon-btn" title="Editor Menu">
                     <i class="fas fa-ellipsis-h"></i>
                 </button>
+                <div id="add-section-dropdown" class="editor-dropdown">
+                    <button id="add-section-btn" class="btn">+ Section</button>
+                    <div id="add-section-menu" class="editor-dropdown-menu">
+                        <button class="dropdown-item" data-section="[Verse]">[Verse]</button>
+                        <button class="dropdown-item" data-section="[Chorus]">[Chorus]</button>
+                        <button class="dropdown-item" data-section="[Bridge]">[Bridge]</button>
+                        <button class="dropdown-item" data-section="[Outro]">[Outro]</button>
+                    </div>
+                </div>
             </div>
             <div class="editor-control-group right-controls">
                 <button id="ai-tools-btn" class="icon-btn" title="AI Tools">
@@ -165,7 +174,7 @@
         <button id="toggle-read-only-btn" class="modal-action-btn"><i class="fas fa-lock"></i> Performance Mode</button>
         <div>
           <label for="edit-mode-select"><i class="fas fa-edit"></i> Edit Mode:</label>
-          <select id="edit-mode-select">
+          <select id="edit-mode-select" class="modal-select">
             <option value="both">Both</option>
             <option value="lyrics">Lyrics</option>
             <option value="chords">Chords</option>

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -41,18 +41,22 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         static showToast(message, type = 'info') {
-            // Remove existing toasts
-            document.querySelectorAll('.toast').forEach(toast => toast.remove());
-            
+            let container = document.querySelector('.toast-container');
+            if (!container) {
+                container = document.createElement('div');
+                container.className = 'toast-container';
+                document.body.appendChild(container);
+            }
+
             const toast = document.createElement('div');
             toast.className = `toast toast-${type}`;
             toast.textContent = message;
-            document.body.appendChild(toast);
-            
+            container.appendChild(toast);
+
             // Trigger animation
             setTimeout(() => toast.classList.add('show'), 10);
-            
-            // Remove after 3 seconds
+
+            // Remove after 3 seconds with fade out
             setTimeout(() => {
                 toast.classList.remove('show');
                 setTimeout(() => toast.remove(), 300);
@@ -147,6 +151,8 @@ document.addEventListener('DOMContentLoaded', () => {
         undoBtn: document.getElementById('undo-btn'),
         redoBtn: document.getElementById('redo-btn'),
         editorMenuBtn: document.getElementById('editor-menu-btn'),
+        addSectionBtn: document.getElementById('add-section-btn'),
+        addSectionMenu: document.getElementById('add-section-menu'),
         aiContextMenu: document.getElementById('ai-context-menu'),
         aiToolsBtn: document.getElementById('ai-tools-btn'),
         aiSettingsBtn: document.getElementById('ai-settings-btn'),
@@ -400,6 +406,23 @@ document.addEventListener('DOMContentLoaded', () => {
             this.rhymeModeToggle?.addEventListener('change', (e) => {
                 this.isRhymeMode = e.target.checked;
                 this.renderLyrics();
+            });
+
+            this.addSectionBtn?.addEventListener('click', (e) => {
+                e.stopPropagation();
+                this.addSectionMenu?.classList.toggle('visible');
+            });
+            this.addSectionMenu?.querySelectorAll('[data-section]').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    const label = e.target.dataset.section;
+                    this.insertSectionAtCursor(label);
+                    this.addSectionMenu.classList.remove('visible');
+                });
+            });
+            document.addEventListener('click', (e) => {
+                if (this.addSectionMenu && !this.addSectionMenu.contains(e.target) && e.target !== this.addSectionBtn) {
+                    this.addSectionMenu.classList.remove('visible');
+                }
             });
 
             this.aiSettingsBtn?.addEventListener('click', () => {
@@ -977,6 +1000,43 @@ document.addEventListener('DOMContentLoaded', () => {
             this.updateReadOnlyState();
             this.updateChordsVisibility();
             this.updateSyllableCount();
+        },
+
+        insertSectionAtCursor(label) {
+            const section = document.createElement('div');
+            section.className = 'section';
+            const header = document.createElement('div');
+            header.className = 'lyrics-line section-label';
+            header.textContent = label;
+            header.setAttribute('contenteditable', !this.isReadOnly);
+            header.addEventListener('click', () => section.classList.toggle('collapsed'));
+            section.appendChild(header);
+            const content = document.createElement('div');
+            content.className = 'section-content';
+            section.appendChild(content);
+
+            const selection = window.getSelection();
+            let node = selection?.focusNode;
+            if (node && node.nodeType === Node.TEXT_NODE) {
+                node = node.parentElement;
+            }
+            const currentSection = node?.closest?.('.section');
+            if (currentSection) {
+                this.lyricsDisplay.insertBefore(section, currentSection.nextSibling);
+            } else {
+                const lineGroup = node?.closest?.('.lyrics-line-group');
+                if (lineGroup) {
+                    this.lyricsDisplay.insertBefore(section, lineGroup);
+                } else {
+                    this.lyricsDisplay.appendChild(section);
+                }
+            }
+
+            header.focus();
+            this.pushUndoState();
+            this.handleLyricsInput();
+            this.saveCurrentSong(true);
+            this.updateReadOnlyState();
         },
 
         addLyricLine(chords, lyrics, rhymeClass, syllableCount, container = this.lyricsDisplay, insertBefore = null) {

--- a/index.html
+++ b/index.html
@@ -52,13 +52,23 @@
                     newWorker.addEventListener('statechange', () => {
                         if (newWorker.state === 'activated') {
                             // Show update toast when new worker activates
+                            let container = document.querySelector('.toast-container');
+                            if (!container) {
+                                container = document.createElement('div');
+                                container.className = 'toast-container';
+                                document.body.appendChild(container);
+                            }
                             const toast = document.createElement('div');
                             toast.className = 'toast toast-info';
                             toast.innerHTML = `
                                 Update available! <a href="#" onclick="window.location.reload()">Refresh</a>
                             `;
-                            document.body.appendChild(toast);
-                            setTimeout(() => toast.remove(), 10000);
+                            container.appendChild(toast);
+                            setTimeout(() => toast.classList.add('show'), 10);
+                            setTimeout(() => {
+                                toast.classList.remove('show');
+                                setTimeout(() => toast.remove(), 300);
+                            }, 10000);
                         }
                     });
                 });

--- a/script.js
+++ b/script.js
@@ -56,18 +56,22 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     static showToast(message, type = 'info') {
-      // Remove existing toasts
-      document.querySelectorAll('.toast').forEach(toast => toast.remove());
-      
+      let container = document.querySelector('.toast-container');
+      if (!container) {
+        container = document.createElement('div');
+        container.className = 'toast-container';
+        document.body.appendChild(container);
+      }
+
       const toast = document.createElement('div');
       toast.className = `toast toast-${type}`;
       toast.textContent = message;
-      document.body.appendChild(toast);
-      
+      container.appendChild(toast);
+
       // Trigger animation
       setTimeout(() => toast.classList.add('show'), 10);
-      
-      // Remove after 3 seconds
+
+      // Remove after 3 seconds with fade out
       setTimeout(() => {
         toast.classList.remove('show');
         setTimeout(() => toast.remove(), 300);
@@ -94,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
     songs: [],
     currentSongId: null,
     defaultSections: "[Intro]\n\n[Verse 1]\n\n[Pre-Chorus]\n\n[Chorus]\n\n[Verse 2]\n\n[Bridge]\n\n[Outro]",
+    sortOrder: localStorage.getItem('songSortOrder') || 'titleAsc',
 
     init() {
       // Load mammoth for DOCX processing
@@ -214,21 +219,31 @@ document.addEventListener('DOMContentLoaded', () => {
 
     highlightMatch(text, query) {
       if (!query) return text;
-      const regex = new RegExp(`(${query})`, 'ig');
-      return text.replace(regex, '<mark>$1</mark>');
+      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const regex = new RegExp(escaped, 'ig');
+      return text.replace(regex, (match) => `<strong>${match}</strong>`);
     },
 
     renderSongs(searchQuery = "") {
       this.songList.innerHTML = '';
 
-      const filtered = this.songs
-        .filter(song => {
-          const titleMatch = song.title.toLowerCase().includes(searchQuery);
-          const tagMatch = song.tags?.some(tag => tag.toLowerCase().includes(searchQuery));
-          const keyMatch = song.key?.toLowerCase().includes(searchQuery);
-          return titleMatch || tagMatch || keyMatch;
-        })
-        .sort((a, b) => a.title.localeCompare(b.title));
+      let filtered = this.songs.filter(song => {
+        const titleMatch = song.title.toLowerCase().includes(searchQuery);
+        const tagMatch = song.tags?.some(tag => tag.toLowerCase().includes(searchQuery));
+        const keyMatch = song.key?.toLowerCase().includes(searchQuery);
+        return titleMatch || tagMatch || keyMatch;
+      });
+
+      filtered.sort((a, b) => {
+        switch (this.sortOrder) {
+          case 'titleDesc':
+            return b.title.localeCompare(a.title);
+          case 'recent':
+            return new Date(b.lastEditedAt) - new Date(a.lastEditedAt);
+          default:
+            return a.title.localeCompare(b.title);
+        }
+      });
 
       if (filtered.length === 0) {
         this.songList.innerHTML = `<p class="empty-state">No songs found.</p>`;
@@ -253,7 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <span class="song-title">${this.highlightMatch(song.title, searchQuery)}</span>
             ${metadata.length > 0 ? `<div class="song-metadata">${metadata.join(' • ')}</div>` : ''}
             <div class="song-details">
-              ${song.tags?.length > 0 ? `<span class="song-tags">${song.tags.join(', ')}</span>` : ''}
+              ${song.tags?.length > 0 ? `<span class="song-tags">${song.tags.map(tag => this.highlightMatch(tag, searchQuery)).join(', ')}</span>` : ''}
               <span class="song-edited">Last edited: ${lastEdited}</span>
             </div>
           </div>
@@ -289,6 +304,12 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         });
 
+        item.addEventListener('click', (e) => {
+          if (!e.target.closest('.song-actions')) {
+            window.location.href = `editor/editor.html?songId=${song.id}`;
+          }
+        });
+
         this.songList.appendChild(item);
       }
     },
@@ -309,6 +330,11 @@ document.addEventListener('DOMContentLoaded', () => {
       const toolbar = document.getElementById('tab-toolbar');
       toolbar.innerHTML = `
         <input type="text" id="song-search-input" class="search-input" placeholder="Search songs, tags, or keys...">
+        <select id="song-sort-select" class="sort-select">
+          <option value="titleAsc">Title A–Z</option>
+          <option value="titleDesc">Title Z–A</option>
+          <option value="recent">Recently Edited</option>
+        </select>
         <div class="toolbar-buttons-group">
           <button id="add-song-btn" class="btn" title="Add Song"><i class="fas fa-plus"></i></button>
           <button id="export-library-btn" class="btn" title="Export Library"><i class="fas fa-download"></i></button>
@@ -318,6 +344,14 @@ document.addEventListener('DOMContentLoaded', () => {
         </div>
         <input type="file" id="song-upload-input" multiple accept=".txt,.docx,.json" class="hidden-file">
       `;
+
+      document.getElementById('song-sort-select').value = this.sortOrder;
+      document.getElementById('song-sort-select')?.addEventListener('change', (e) => {
+        this.sortOrder = e.target.value;
+        localStorage.setItem('songSortOrder', this.sortOrder);
+        const query = document.getElementById('song-search-input')?.value.toLowerCase() || '';
+        this.renderSongs(query);
+      });
 
       document.getElementById('add-song-btn')?.addEventListener('click', () => this.createNewSong());
       document.getElementById('export-library-btn')?.addEventListener('click', () => this.exportLibrary());

--- a/style.css
+++ b/style.css
@@ -204,6 +204,16 @@ mark {
     color: var(--text-secondary);
 }
 
+.sort-select {
+    font-size: 0.95rem;
+    padding: 0.3rem 0.6rem;
+    border-radius: var(--border-radius-base);
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    margin-left: 0.5rem;
+}
+
 .page-content, .tab {
   overflow: visible !important;
 }
@@ -657,36 +667,6 @@ mark {
     resize: vertical;
     font-family: inherit;
     font-size: 1rem;
-}
-
-/* Add these styles to your existing CSS */
-
-/* Toast notifications */
-.toast {
-    position: fixed;
-    top: 20px;
-    right: 20px;
-    padding: 12px 20px;
-    border-radius: 6px;
-    color: white;
-    font-weight: 500;
-    z-index: 10000;
-    opacity: 0;
-    transform: translateX(100%);
-    transition: all 0.3s ease;
-}
-
-.toast.show {
-    opacity: 1;
-    transform: translateX(0);
-}
-
-.toast-success {
-    background-color: #10b981;
-}
-
-.toast-error {
-    background-color: #ef4444;
 }
 
 /* Empty state messages */
@@ -1259,6 +1239,7 @@ html, body {
     border: 1px solid var(--border-light);
     box-shadow: var(--shadow-sm);
     transition: all var(--transition-speed);
+    cursor: pointer;
 }
 
 .song-item:hover {
@@ -1397,16 +1378,23 @@ html, body {
 /* ========================================
     Toast Notification Styles
     ======================================== */
-.toast {
+.toast-container {
     position: fixed;
     top: 20px;
     right: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 10000;
+}
+
+.toast {
+    position: relative;
     padding: 0.75rem 1rem;
     border-radius: var(--border-radius-base);
     color: white;
     font-weight: 500;
     font-size: 0.9rem;
-    z-index: 10000;
     opacity: 0;
     transform: translateX(100%);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1469,15 +1457,18 @@ html, body {
     }
     
 
-    .toast {
+    .toast-container {
         top: auto;
         bottom: 20px;
         right: 20px;
         left: 20px;
-        max-width: none;
-        transform: translateY(100%);
     }
-    
+
+    .toast {
+        transform: translateY(100%);
+        max-width: none;
+    }
+
     .toast.show {
         transform: translateY(0);
     }


### PR DESCRIPTION
## Summary
- add quick section dropdown for inserting common song sections
- make song list items clickable with bolded search matches and persistent sorting
- allow multiple toast notifications to stack and fade out

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee130f88832a9afe13ea6f833427