### PR TITLE
Enhance editor UI and section controls

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -463,6 +463,27 @@
   border-color: var(--accent-primary);
   box-shadow: 0 0 0 2px var(--accent-glow);
 }
+.modal-item {
+  background: var(--bg-tertiary);
+  padding: 0.5rem;
+  border-radius: var(--border-radius-base);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.modal-item label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  color: var(--text-primary);
+}
+.modal-item select {
+  flex: 1;
+}
+.modal-item input[type="checkbox"] {
+  margin-right: 0.25rem;
+}
 .modal-action-btn,
 .modal-copy-btn {
   background: var(--accent-primary);
@@ -500,8 +521,12 @@
 /* Section-based editing */
 .section-label {
     font-weight: bold;
-    cursor: pointer;
+    cursor: grab;
     margin-top: 1em;
+}
+
+.section-label:active {
+    cursor: grabbing;
 }
 
 .section.collapsed .section-content {
@@ -577,6 +602,15 @@
 }
 .footer-controls .control-label {
     font-size: 0.9em;
+}
+.font-size-display {
+    font-weight: bold;
+    background: var(--bg-tertiary);
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--border-radius-base);
+    box-shadow: var(--shadow-sm);
+    min-width: 3rem;
+    text-align: center;
 }
 
 .copy-option {
@@ -769,6 +803,49 @@ toolbar {
 }
 
 .ai-context-menu button:active {
+    transform: scale(0.97);
+}
+
+.section-menu {
+    position: absolute;
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--border-radius-base);
+    box-shadow: var(--shadow-lg);
+    padding: 0.25rem;
+    display: none;
+    z-index: 99999;
+    gap: 0.25rem;
+}
+
+.section-menu button {
+    background: var(--accent-primary);
+    border: none;
+    color: #fff;
+    padding: 0.35rem 0.5rem;
+    border-radius: var(--border-radius-base);
+    font-size: 0.85rem;
+    cursor: pointer;
+}
+
+.section-menu button i {
+    margin-right: 0.25rem;
+}
+
+.section-menu .section-menu-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    margin-left: auto;
+    padding: 0.25rem;
+    cursor: pointer;
+}
+
+.section-menu .section-menu-close:hover {
+    color: var(--accent-primary);
+}
+
+.section-menu button:active {
     transform: scale(0.97);
 }
 

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -11,6 +11,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"></script>
     <style>
         /* Additional styles for metadata panel */
         .metadata-panel {
@@ -95,27 +96,21 @@
 
         <div class="editor-header">
             <div class="editor-control-group left-controls">
-                <button id="editor-menu-btn" class="icon-btn" title="Editor Menu">
+                <button id="editor-menu-btn" class="btn icon-btn" title="Editor Menu">
                     <i class="fas fa-ellipsis-h"></i>
                 </button>
-                <div id="add-section-dropdown" class="editor-dropdown">
-                    <button id="add-section-btn" class="btn">+ Section</button>
-                    <div id="add-section-menu" class="editor-dropdown-menu">
-                        <button class="dropdown-item" data-section="[Verse]">[Verse]</button>
-                        <button class="dropdown-item" data-section="[Chorus]">[Chorus]</button>
-                        <button class="dropdown-item" data-section="[Bridge]">[Bridge]</button>
-                        <button class="dropdown-item" data-section="[Outro]">[Outro]</button>
-                    </div>
-                </div>
+                <button id="add-section-btn" class="btn icon-btn" title="Add Section">
+                    <i class="fas fa-plus"></i>
+                </button>
             </div>
             <div class="editor-control-group right-controls">
-                <button id="ai-tools-btn" class="icon-btn" title="AI Tools">
+                <button id="ai-tools-btn" class="btn icon-btn" title="AI Tools">
                     <i class="fas fa-robot"></i>
                 </button>
-                <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Theme">
+                <button id="theme-toggle-btn" class="btn icon-btn theme-toggle-btn" title="Toggle Theme">
                     <i class="fas fa-adjust"></i>
                 </button>
-                <button id="exit-editor-btn" class="icon-btn" title="Exit Editor">
+                <button id="exit-editor-btn" class="btn icon-btn" title="Exit Editor">
                     <i class="fas fa-times"></i>
                 </button>
             </div>
@@ -138,13 +133,20 @@
             <button id="ai-menu-close" class="ai-menu-close"><i class="fas fa-times"></i></button>
         </div>
 
+        <div id="section-menu" class="section-menu">
+            <button data-action="rename"><i class="fas fa-i-cursor"></i> Rename</button>
+            <button data-action="delete-label"><i class="fas fa-tag"></i> Delete Label</button>
+            <button data-action="delete-section"><i class="fas fa-trash"></i> Delete Label + Lyrics</button>
+            <button id="section-menu-close" class="section-menu-close"><i class="fas fa-times"></i></button>
+        </div>
+
         <div class="editor-footer">
             <div class="footer-controls">
-                <button id="decrease-font-btn" class="icon-btn" title="Decrease Font Size">
+                <button id="decrease-font-btn" class="btn icon-btn" title="Decrease Font Size">
                     <i class="fas fa-minus"></i>
                 </button>
-                <span id="font-size-display"></span>
-                <button id="increase-font-btn" class="icon-btn" title="Increase Font Size">
+                <span id="font-size-display" class="font-size-display"></span>
+                <button id="increase-font-btn" class="btn icon-btn" title="Increase Font Size">
                     <i class="fas fa-plus"></i>
                 </button>
             </div>
@@ -172,13 +174,16 @@
         <h2>Editor Options</h2>
         <button id="toggle-chords-btn" class="modal-action-btn"><i class="fas fa-guitar"></i> Toggle Chords</button>
         <button id="toggle-read-only-btn" class="modal-action-btn"><i class="fas fa-lock"></i> Performance Mode</button>
-        <div>
-          <label for="edit-mode-select"><i class="fas fa-edit"></i> Edit Mode:</label>
+        <div class="modal-item">
+          <label for="edit-mode-select"><i class="fas fa-edit"></i> Edit Mode</label>
           <select id="edit-mode-select" class="modal-select">
             <option value="both">Both</option>
             <option value="lyrics">Lyrics</option>
             <option value="chords">Chords</option>
           </select>
+        </div>
+        <div class="modal-item">
+          <label><input type="checkbox" id="rhyme-mode-toggle"> <i class="fas fa-bullseye"></i> Rhyme Colors</label>
         </div>
         <button id="save-song-btn" class="modal-action-btn"><i class="fas fa-save"></i> Save Song</button>
         <button id="copy-lyrics-btn" class="modal-action-btn"><i class="fas fa-copy"></i> Copy Options</button>
@@ -199,6 +204,19 @@
         <button id="ai-format-btn" class="modal-action-btn"><i class="fas fa-broom"></i> Clean Format (AI)</button>
         <button id="regenre-btn" class="modal-action-btn"><i class="fas fa-random"></i> Re-Genre (AI)</button>
         <button id="ai-settings-btn" class="modal-action-btn"><i class="fas fa-cog"></i> Settings</button>
+        <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
+      </div>
+    </div>
+
+    <div id="add-section-modal" class="modal-overlay">
+      <div class="modal">
+        <h2>Add Section</h2>
+        <button class="modal-action-btn" data-section="[Intro]"><i class="fas fa-play"></i> Intro</button>
+        <button class="modal-action-btn" data-section="[Pre-Chorus]"><i class="fas fa-step-forward"></i> Pre-Chorus</button>
+        <button class="modal-action-btn" data-section="[Verse]"><i class="fas fa-microphone-alt"></i> Verse</button>
+        <button class="modal-action-btn" data-section="[Chorus]"><i class="fas fa-music"></i> Chorus</button>
+        <button class="modal-action-btn" data-section="[Bridge]"><i class="fas fa-link"></i> Bridge</button>
+        <button class="modal-action-btn" data-section="[Outro]"><i class="fas fa-flag-checkered"></i> Outro</button>
         <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
       </div>
     </div>

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -152,7 +152,7 @@ document.addEventListener('DOMContentLoaded', () => {
         redoBtn: document.getElementById('redo-btn'),
         editorMenuBtn: document.getElementById('editor-menu-btn'),
         addSectionBtn: document.getElementById('add-section-btn'),
-        addSectionMenu: document.getElementById('add-section-menu'),
+        addSectionModal: document.getElementById('add-section-modal'),
         aiContextMenu: document.getElementById('ai-context-menu'),
         aiToolsBtn: document.getElementById('ai-tools-btn'),
         aiSettingsBtn: document.getElementById('ai-settings-btn'),
@@ -164,6 +164,7 @@ document.addEventListener('DOMContentLoaded', () => {
         saveAISettingsBtn: document.getElementById('save-ai-settings'),
         measureModeToggle: document.getElementById('measure-mode-toggle'),
         rhymeModeToggle: document.getElementById('rhyme-mode-toggle'),
+        sectionMenu: document.getElementById('section-menu'),
 
         // State (keeping existing and adding new)
         songs: [],
@@ -188,6 +189,8 @@ document.addEventListener('DOMContentLoaded', () => {
         selectedModel: '',
         undoStack: [],
         redoStack: [],
+        sectionMenuTarget: null,
+        sectionSortable: null,
         lastSnapshotTime: 0,
 
         syllableCount(word) {
@@ -205,6 +208,9 @@ document.addEventListener('DOMContentLoaded', () => {
             this.loadEditorState();
             if (this.editModeSelect) {
                 this.editModeSelect.value = this.editMode;
+            }
+            if (this.rhymeModeToggle) {
+                this.rhymeModeToggle.checked = this.isRhymeMode;
             }
             this.displayCurrentEditorSong();
             this.setupResizeObserver();
@@ -432,21 +438,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.renderLyrics();
             });
 
-            this.addSectionBtn?.addEventListener('click', (e) => {
-                e.stopPropagation();
-                this.addSectionMenu?.classList.toggle('visible');
+            this.addSectionBtn?.addEventListener('click', () => {
+                this.addSectionModal?.classList.add('visible');
             });
-            this.addSectionMenu?.querySelectorAll('[data-section]').forEach(btn => {
+            this.addSectionModal?.querySelectorAll('[data-section]').forEach(btn => {
                 btn.addEventListener('click', (e) => {
-                    const label = e.target.dataset.section;
+                    const label = e.currentTarget.dataset.section;
                     this.insertSectionAtCursor(label);
-                    this.addSectionMenu.classList.remove('visible');
+                    this.addSectionModal.classList.remove('visible');
                 });
             });
-            document.addEventListener('click', (e) => {
-                if (this.addSectionMenu && !this.addSectionMenu.contains(e.target) && e.target !== this.addSectionBtn) {
-                    this.addSectionMenu.classList.remove('visible');
-                }
+            this.addSectionModal?.querySelector('.close-modal-btn')?.addEventListener('click', () => {
+                this.addSectionModal.classList.remove('visible');
             });
 
             this.aiSettingsBtn?.addEventListener('click', () => {
@@ -465,7 +468,11 @@ document.addEventListener('DOMContentLoaded', () => {
             this.lyricsDisplay?.addEventListener('mouseup', () => this.cancelLongPress());
             this.lyricsDisplay?.addEventListener('contextmenu', (e) => {
                 e.preventDefault();
-                this.handleTextSelection();
+                if (e.target.classList.contains('section-label')) {
+                    this.openSectionMenu(e);
+                } else {
+                    this.handleTextSelection();
+                }
             });
             document.querySelectorAll('#ai-context-menu button[data-action]').forEach(btn => {
                 btn.addEventListener('click', () => {
@@ -479,11 +486,24 @@ document.addEventListener('DOMContentLoaded', () => {
                 this.aiContextMenu.style.display = 'none';
                 window.getSelection()?.removeAllRanges();
             });
+            this.sectionMenu?.querySelectorAll('button[data-action]')?.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const action = btn.dataset.action;
+                    this.handleSectionMenuAction(action);
+                    this.sectionMenu.style.display = 'none';
+                });
+            });
+            document.getElementById('section-menu-close')?.addEventListener('click', () => {
+                this.sectionMenu.style.display = 'none';
+            });
             document.addEventListener('click', (e) => {
                 if (this.aiContextMenu.style.display === 'flex' &&
                     !this.aiContextMenu.contains(e.target)) {
                     this.aiContextMenu.style.display = 'none';
                     window.getSelection()?.removeAllRanges();
+                }
+                if (this.sectionMenu && this.sectionMenu.style.display === 'flex' && !this.sectionMenu.contains(e.target)) {
+                    this.sectionMenu.style.display = 'none';
                 }
             });
 
@@ -634,6 +654,51 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 this.aiContextMenu.style.display = 'none';
             }
+        },
+
+        openSectionMenu(e) {
+            if (!this.sectionMenu) return;
+            this.sectionMenuTarget = e.target.closest('.section');
+            if (this.aiContextMenu) this.aiContextMenu.style.display = 'none';
+            this.sectionMenu.style.display = 'flex';
+            this.sectionMenu.style.left = `${e.pageX}px`;
+            this.sectionMenu.style.top = `${e.pageY}px`;
+        },
+
+        handleSectionMenuAction(action) {
+            if (!this.sectionMenuTarget) return;
+            const section = this.sectionMenuTarget;
+            if (action === 'rename') {
+                const label = section.querySelector('.section-label');
+                label?.focus();
+                document.execCommand?.('selectAll', false, null);
+            } else if (action === 'delete-label') {
+                const content = section.querySelector('.section-content');
+                while (content.firstChild) {
+                    this.lyricsDisplay.insertBefore(content.firstChild, section);
+                }
+                section.remove();
+                this.handleLyricsInput();
+                this.initSectionDrag();
+            } else if (action === 'delete-section') {
+                section.remove();
+                this.handleLyricsInput();
+                this.initSectionDrag();
+            }
+            this.sectionMenuTarget = null;
+        },
+
+        initSectionDrag() {
+            if (!this.lyricsDisplay || typeof Sortable === 'undefined') return;
+            if (this.sectionSortable) {
+                this.sectionSortable.destroy();
+            }
+            this.sectionSortable = Sortable.create(this.lyricsDisplay, {
+                animation: 150,
+                handle: '.section-label',
+                draggable: '.section',
+                onEnd: () => this.handleLyricsInput()
+            });
         },
 
         handleAIAction(action, selectedText) {
@@ -967,6 +1032,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     header.textContent = lyricLine.trim();
                     header.setAttribute('contenteditable', 'true');
                     header.addEventListener('click', () => section.classList.toggle('collapsed'));
+                    header.addEventListener('input', () => this.handleLyricsInput());
                     section.appendChild(header);
                     const content = document.createElement('div');
                     content.className = 'section-content';
@@ -1009,6 +1075,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
             this.lyricsDisplay.style.fontSize = `${this.fontSize}px`;
+            this.initSectionDrag();
             this.updateReadOnlyState();
             this.updateChordsVisibility();
             this.updateSyllableCount();
@@ -1022,6 +1089,7 @@ document.addEventListener('DOMContentLoaded', () => {
             header.textContent = label;
             header.setAttribute('contenteditable', !this.isReadOnly);
             header.addEventListener('click', () => section.classList.toggle('collapsed'));
+            header.addEventListener('input', () => this.handleLyricsInput());
             section.appendChild(header);
             const content = document.createElement('div');
             content.className = 'section-content';
@@ -1044,6 +1112,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
             }
 
+            this.initSectionDrag();
             header.focus();
             this.pushUndoState();
             this.handleLyricsInput();

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <div class="app-logo">
           <img src="assets/images/mylogo.png" alt="App Logo" class="app-logo-img">
         </div>
-        <button id="theme-toggle-btn" class="icon-btn theme-toggle-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme" style="position:absolute;top:1.1rem;right:1.1rem;">
+        <button id="theme-toggle-btn" class="btn icon-btn theme-toggle-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme">
           <i class="fas fa-adjust"></i>
         </button>
       </div>

--- a/style.css
+++ b/style.css
@@ -163,12 +163,20 @@ mark {
 .header-top {
     display: flex;
     align-items: center;
-    width: 40%;
-    margin-bottom: 3rem;
-    margin-top: 1.5rem;
-    justify-content: space-between;
-    padding: 0.29rem 1.2rem 0.11rem 1.27rem;
-    gap: 1.2rem;
+    justify-content: center;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    gap: 1rem;
+    flex-wrap: wrap;
+    position: relative;
+}
+
+.app-logo-img {
+    max-height: 40px;
+}
+
+.theme-toggle-btn {
+    margin-left: auto;
 }
 
 .theme-toggle-wrapper {
@@ -291,6 +299,15 @@ mark {
   opacity: 1;
 }
 
+.btn.icon-btn {
+  padding: 0.5rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .theme-icon-btn {
   position: absolute;
   top: 1.1rem;
@@ -316,11 +333,13 @@ mark {
         padding: 0 0 0.5rem 0;
     }
     .header-top {
-	flex-direction: column;
+        flex-direction: row;
         align-items: center;
         justify-content: center;
-        padding-left: 0 !important;
-        padding-right: 0 !important;
+        padding: 0.5rem;
+    }
+    .app-logo-img {
+        max-height: 32px;
     }
     .app-title {
         font-size: 1.08rem;


### PR DESCRIPTION
## Summary
- Polish header layout and unify icon button styling across the app
- Add rhyme color toggle and themed "Add Section" modal with new section types
- Enable section drag/drop with context menu for renaming or deleting sections

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896765d2d94832a9c971d6664fe8958