### PR TITLE
Add PWA install prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,14 @@
         <div class="app-logo">
           <img src="assets/images/mylogo.png" alt="App Logo" class="app-logo-img">
         </div>
-        <button id="theme-toggle-btn" class="btn icon-btn theme-toggle-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme">
-          <i class="fas fa-adjust"></i>
-        </button>
+        <div class="header-actions">
+          <button id="install-btn" class="btn icon-btn install-btn" title="Install app" aria-label="Install app">
+            <i class="fas fa-download"></i>
+          </button>
+          <button id="theme-toggle-btn" class="btn icon-btn theme-toggle-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme">
+            <i class="fas fa-adjust"></i>
+          </button>
+        </div>
       </div>
       <div id="tab-toolbar" class="toolbar"></div>
     </header>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,29 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.setItem('theme', newTheme);
   });
 
+  // === PWA INSTALL PROMPT ===
+  const installBtn = document.getElementById('install-btn');
+  let deferredPrompt;
+
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    installBtn.style.display = 'inline-flex';
+  });
+
+  installBtn?.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    installBtn.style.display = 'none';
+    deferredPrompt.prompt();
+    await deferredPrompt.userChoice;
+    deferredPrompt = null;
+  });
+
+  window.addEventListener('appinstalled', () => {
+    installBtn.style.display = 'none';
+    deferredPrompt = null;
+  });
+
   // === CLIPBOARD MANAGER ===
   class ClipboardManager {
     static async copyToClipboard(text, showToast = true) {

--- a/style.css
+++ b/style.css
@@ -179,6 +179,21 @@ mark {
     margin-left: auto;
 }
 
+.header-actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.header-actions .theme-toggle-btn {
+    margin-left: 0;
+}
+
+.install-btn {
+    display: none;
+}
+
 .theme-toggle-wrapper {
     min-width: 120px;
     display: flex;


### PR DESCRIPTION
## Summary
- add install button and layout to header
- wire up beforeinstallprompt event for custom install prompt
- style install button and right-side header actions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d702161f0832ab29e5cb5d4944728