### PR TITLE
Maintain uniform horizontal toolbar buttons

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -57,6 +57,7 @@
 .editor-control-group {
     display: flex;
     align-items: center;
+    flex-wrap: nowrap;
     gap: 1.25rem;
     padding: 0.5rem;
     border-radius: 0.75rem;
@@ -652,10 +653,11 @@
 
 /* MOBILE POLISH PATCH */
 @media (max-width: 600px) {
-toolbar {
-    flex-wrap: wrap;
+  toolbar {
+    flex-wrap: nowrap;
     justify-content: space-between;
     gap: 0.4em;
+    overflow-x: auto;
   }
 
   .setlist-editor {
@@ -666,7 +668,8 @@ toolbar {
   .editor-header {
     padding: 0.3em 0.5em;
     font-size: 0.8em;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    overflow-x: auto;
     gap: 0.5em;
   }
 
@@ -678,6 +681,7 @@ toolbar {
 
   .editor-control-group {
     gap: 0.7em;
+    flex-wrap: nowrap;
   }
 
   #lyrics-display {

--- a/style.css
+++ b/style.css
@@ -1590,3 +1590,27 @@ html, body {
   .app-logo-img { max-height: 80px; }
 }
 
+/* Ensure toolbar buttons are uniform and horizontal across all screens */
+.toolbar,
+.toolbar-buttons-group,
+.editor-control-group {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    align-items: center;
+}
+
+.toolbar-buttons-group > .btn,
+.toolbar-buttons-group > label.btn,
+.editor-control-group > .btn {
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.toolbar-buttons-group > .sort-select {
+    height: 2.5rem;
+}


### PR DESCRIPTION
## Summary
- Enforce consistent square sizing for toolbar buttons and keep toolbar items in a single horizontal row with overflow scrolling.
- Prevent editor toolbar controls from wrapping on small screens by using no-wrap flex settings.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d80bdce44832a9784c43a066ade6a