### PR TITLE
Ensure editor footer remains sticky

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -732,6 +732,10 @@ toolbar {
     padding: 0.5em 1em;
     background-color: var(--bg-secondary);
     border-top: 1px solid var(--border);
+    position: sticky;
+    bottom: 0;
+    left: 0;
+    width: 100%;
   }
 
   .footer-controls {


### PR DESCRIPTION
## Summary
- Make editor footer sticky within the mobile layout to stay visible at the bottom

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d826832f0832ab72677e069616d31