### PR TITLE
Refine header and song action UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
         <div class="app-logo">
           <img src="assets/images/mylogo.png" alt="App Logo" class="app-logo-img">
         </div>
+        <button id="theme-toggle-btn" class="theme-icon-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme"><i class="fas fa-adjust"></i></button>
       </div>
       <div id="tab-toolbar" class="toolbar"></div>
     </header>
@@ -35,13 +36,6 @@
         </div>
       </section>
     </main>
-  </div>
-  <div id="install-banner" class="install-banner hidden">
-    <span class="install-message">Install LyricSmith?</span>
-    <div class="install-actions">
-      <button id="install-accept" class="btn">Install</button>
-      <button id="install-dismiss" class="btn">Not now</button>
-    </div>
   </div>
     <script>
         // Register service worker and check for updates

--- a/script.js
+++ b/script.js
@@ -23,107 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
       localStorage.setItem('theme', newTheme);
     });
   }
-
-  // === PWA INSTALL / UNINSTALL ===
-  let deferredPrompt;
-  let pwaInstalled =
-    window.matchMedia('(display-mode: standalone)').matches ||
-    window.navigator.standalone === true ||
-    localStorage.getItem('pwaInstalled') === 'true';
-  const INSTALL_PROMPT_INTERVAL = 0; // days between prompts; 0 = every session
-
-  function shouldShowPrompt() {
-    if (INSTALL_PROMPT_INTERVAL <= 0) return true;
-    const last = parseInt(localStorage.getItem('lastInstallPrompt'), 10);
-    return !last || Date.now() - last > INSTALL_PROMPT_INTERVAL * 86400000;
-  }
-
-  function recordPromptTime() {
-    localStorage.setItem('lastInstallPrompt', Date.now().toString());
-  }
-
-  async function clearServiceWorkers() {
-    const regs = await navigator.serviceWorker.getRegistrations();
-    for (const reg of regs) await reg.unregister();
-    if (window.caches) {
-      const keys = await caches.keys();
-      await Promise.all(keys.map(key => caches.delete(key)));
-    }
-  }
-
-  function updateInstallButton() {
-    const installBtn = document.getElementById('install-btn');
-    if (!installBtn) return;
-    if (pwaInstalled) {
-      installBtn.innerHTML = '<i class="fas fa-trash"></i>';
-      installBtn.title = 'Uninstall app';
-      installBtn.setAttribute('aria-label', 'Uninstall app');
-      installBtn.style.display = 'inline-flex';
-      installBtn.onclick = async () => {
-        await clearServiceWorkers();
-        localStorage.removeItem('pwaInstalled');
-        pwaInstalled = false;
-        updateInstallButton();
-      };
-    } else {
-      installBtn.innerHTML = '<i class="fas fa-download"></i>';
-      installBtn.title = 'Install app';
-      installBtn.setAttribute('aria-label', 'Install app');
-      installBtn.style.display = deferredPrompt ? 'inline-flex' : 'none';
-      installBtn.onclick = async () => {
-        if (!deferredPrompt) return;
-        deferredPrompt.prompt();
-        await deferredPrompt.userChoice;
-        deferredPrompt = null;
-      };
-    }
-  }
-
-  function showInstallBanner() {
-    if (!deferredPrompt || pwaInstalled || sessionStorage.getItem('installDismissed') === 'true') return;
-    if (!shouldShowPrompt()) return;
-    const banner = document.getElementById('install-banner');
-    banner.classList.remove('hidden');
-    recordPromptTime();
-  }
-
-  function hideInstallBanner() {
-    const banner = document.getElementById('install-banner');
-    banner.classList.add('hidden');
-    sessionStorage.setItem('installDismissed', 'true');
-  }
-
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferredPrompt = e;
-    updateInstallButton();
-    showInstallBanner();
-  });
-
-  document.getElementById('install-accept')?.addEventListener('click', async () => {
-    if (!deferredPrompt) return;
-    deferredPrompt.prompt();
-    const choice = await deferredPrompt.userChoice;
-    deferredPrompt = null;
-    hideInstallBanner();
-    if (choice.outcome === 'accepted') {
-      pwaInstalled = true;
-      localStorage.setItem('pwaInstalled', 'true');
-      updateInstallButton();
-    }
-  });
-
-  document.getElementById('install-dismiss')?.addEventListener('click', () => {
-    hideInstallBanner();
-  });
-
-  window.addEventListener('appinstalled', () => {
-    pwaInstalled = true;
-    localStorage.setItem('pwaInstalled', 'true');
-    deferredPrompt = null;
-    hideInstallBanner();
-    updateInstallButton();
-  });
+  attachThemeToggle();
 
   // === CLIPBOARD MANAGER ===
   class ClipboardManager {
@@ -393,10 +293,10 @@ document.addEventListener('DOMContentLoaded', () => {
             <button class="song-copy-btn icon-btn" title="Quick Copy" aria-label="Quick copy ${song.title}" data-song-id="${song.id}">
               <i class="fas fa-copy"></i>
             </button>
-            <a class="song-edit-btn edit-song-btn" href="editor/editor.html?songId=${song.id}" title="Edit" aria-label="Edit ${song.title}">
+            <a class="song-edit-btn icon-btn edit-song-btn" href="editor/editor.html?songId=${song.id}" title="Edit" aria-label="Edit ${song.title}">
               <i class="fas fa-pen"></i>
             </a>
-            <button class="song-delete-btn danger delete-song-btn" title="Delete" aria-label="Delete ${song.title}" data-song-id="${song.id}">
+            <button class="song-delete-btn icon-btn delete-song-btn" title="Delete" aria-label="Delete ${song.title}" data-song-id="${song.id}">
               <i class="fas fa-trash"></i>
             </button>
           </div>
@@ -483,13 +383,9 @@ document.addEventListener('DOMContentLoaded', () => {
           <button id="import-clipboard-btn" class="btn icon-btn" title="Paste Song"><i class="fas fa-paste"></i></button>
           <button id="delete-all-songs-btn" class="btn icon-btn danger" title="Delete All Songs"><i class="fas fa-trash"></i></button>
           <label for="song-upload-input" class="btn icon-btn" title="Upload Files"><i class="fas fa-upload"></i></label>
-          <button id="install-btn" class="btn icon-btn install-btn" title="Install app" aria-label="Install app"><i class="fas fa-download"></i></button>
-          <button id="theme-toggle-btn" class="btn icon-btn theme-toggle-btn" title="Toggle Light/Dark" aria-label="Toggle light or dark theme"><i class="fas fa-adjust"></i></button>
         </div>
         <input type="file" id="song-upload-input" multiple accept=".txt,.docx,.json" class="hidden-file">
       `;
-      attachThemeToggle();
-      updateInstallButton();
 
       document.getElementById('song-sort-select').value = this.sortOrder;
       document.getElementById('song-sort-select')?.addEventListener('change', (e) => {

--- a/style.css
+++ b/style.css
@@ -176,38 +176,6 @@ mark {
 }
 
 
-.header-top .theme-toggle-btn {
-    margin-left: auto;
-}
-
-.install-btn {
-    display: none;
-}
-
-.install-banner {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    padding: 0.8rem 1rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    box-shadow: 0 -2px 6px rgba(0,0,0,0.2);
-    z-index: 1000;
-}
-
-.install-banner.hidden {
-    display: none;
-}
-
-.install-banner .install-actions {
-    display: flex;
-    gap: 0.5rem;
-}
-
 .theme-toggle-wrapper {
     min-width: 120px;
     display: flex;
@@ -330,12 +298,12 @@ mark {
 
 .theme-icon-btn {
   position: absolute;
-  top: 1.1rem;
-  right: 1.1rem;
+  top: 0.5rem;
+  right: 0.5rem;
   background: none;
   border: none;
   color: var(--accent-secondary, #888);
-  font-size: 1.rem;
+  font-size: 1rem;
   cursor: pointer;
   opacity: 0.82;
   z-index: 100;
@@ -512,6 +480,7 @@ mark {
     gap: 0.5rem;
     margin-bottom: var(--padding-base);
     align-items: stretch;
+    padding: 0 0.5rem;
 }
 
 /* Group wrapper for toolbar buttons */
@@ -532,7 +501,7 @@ mark {
 
 .search-input {
     width: 100%;
-    padding: 0.5rem;
+    padding: 0.5rem 0.75rem;
     margin: 0;
     background-color: var(--bg-hover); /* Inputs use tertiary background */
     color: var(--text-primary);
@@ -1120,33 +1089,6 @@ html, body {
 }
 
 
-.song-delete-btn {
-    background-color: var(--accent-primary); /* Buttons use accent primary */
-    color: var(--text-primary); /* Text on buttons should contrast, using bg-primary for dark themes */
-    border: none;
-    margin-left: 0.3rem;
-    min-width: 1rem !important;
-    max-width: 2.3rem !important;
-    padding: 0.5rem 0.9rem !important;
-    font-size: 0.7rem !important;
-    border-radius: var(--border-radius-base); /* Using base border radius */
-    cursor: pointer;
-    transition: background-color var(--transition-speed), color var(--transition-speed), box-shadow var(--transition-speed);
-    box-shadow: var(--shadow-sm); /* Adding a subtle shadow to buttons */
-}
-
-.song-edit-btn {
-    background-color: var(--accent-primary); /* Buttons use accent primary */
-    color: var(--bg-primary); /* Text on buttons should contrast, using bg-primary for dark themes */
-    border: none;
-    min-width: 1rem !important;
-    padding: 0.5rem 0.7rem !important;
-    font-size: 0.7rem !important;
-    border-radius: var(--border-radius-base); /* Using base border radius */
-    cursor: pointer;
-    transition: background-color var(--transition-speed), color var(--transition-speed), box-shadow var(--transition-speed);
-    box-shadow: var(--shadow-sm); /* Adding a subtle shadow to buttons */
-}
 
 /* ========================================
     Enhanced Song List Styles
@@ -1210,6 +1152,7 @@ html, body {
     color: var(--text-muted);
 }
 
+
 .song-actions {
     display: flex;
     gap: 0.25rem;
@@ -1217,7 +1160,7 @@ html, body {
     flex-shrink: 0;
 }
 
-.song-copy-btn {
+.song-actions .icon-btn {
     background: var(--bg-secondary);
     color: var(--accent-secondary);
     border: 1px solid var(--border);
@@ -1232,7 +1175,7 @@ html, body {
     position: relative;
 }
 
-.song-copy-btn:hover {
+.song-actions .icon-btn:hover {
     background: var(--accent-primary);
     color: var(--bg-primary);
     transform: scale(1.05);
@@ -1361,10 +1304,8 @@ html, body {
         justify-content: flex-end;
         gap: 0.5rem;
     }
-    
-    .song-copy-btn,
-    .song-edit-btn,
-    .song-delete-btn {
+
+    .song-actions .icon-btn {
         width: 2.25rem;
         height: 2.25rem;
         font-size: 0.9rem;
@@ -1422,10 +1363,8 @@ html, body {
     .song-actions {
         gap: 0.3rem;
     }
-    
-    .song-copy-btn,
-    .song-edit-btn,
-    .song-delete-btn {
+
+    .song-actions .icon-btn {
         width: 2rem;
         height: 2rem;
         font-size: 0.8rem;
@@ -1458,39 +1397,6 @@ html, body {
   width: auto;
 }
 
-/* Theme toggle: inline-right in header */
-.header-top .theme-toggle-btn {
-  margin-left: auto;
-}
-
-/* ===== Mobile (logo centered + big, theme in top-right corner) ===== */
-@media (max-width: 700px) {
-  .header-top {
-    justify-content: center;
-    padding: 0.5rem 0.8rem;
-    width: 100% !important;   /* nuke older 50%/70% rules */
-  }
-
-  .app-logo { 
-    flex: 1 1 100%;
-    justify-content: center; 
-  }
-
-  .app-logo-img {
-    max-height: none;                 /* switch from height cap… */
-    max-width: min(540px, 84vw);      /* …to wide, centered image */
-  }
-
-  /* park the theme toggle in the corner */
-  .header-top .theme-toggle-btn {
-    position: absolute;
-    top: 0rem;
-    right: 0.7rem;
-    margin: 0;                        /* ignore the flex auto-margin */
-    padding: 0.35rem;
-    font-size: 1.2rem;                /* tap-friendly, not huge */
-  }
-}
 
 /* ===== Tablet tune-up ===== */
 @media (min-width: 700px) and (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- Drop PWA install/uninstall UI
- Move theme toggle to header corner and shrink icon
- Pad search bar and unify song action button styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9c4e6c2c832a9fcf2580a9dabe6f