### PR TITLE
fix: prevent lyrics truncation in editor

### DIFF
--- a/style.css
+++ b/style.css
@@ -1087,7 +1087,7 @@ html, body {
   }
 
   .song-title,
-  .song-item span, span {
+  .song-item span {
     max-width: 70vw !important;
     white-space: nowrap !important;
     overflow: hidden !important;


### PR DESCRIPTION
## Summary
- stop global span styling from cutting off editor text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d9c918d68832a894cf7eb972fa823