### PR TITLE
Improve section handling and keep editor header visible

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -34,8 +34,11 @@
     border-radius: 0 0 1rem 1rem;
     box-shadow: 0 2px 12px rgba(0,0,0,0.08);
     backdrop-filter: blur(6px);
-    margin: 0.5rem;
-    width: calc(100% - 1rem);
+    margin: 0;
+    width: 100%;
+    position: sticky;
+    top: 0;
+    z-index: 1000;
 }
 
 .editor-header h2,

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -637,9 +637,15 @@ function enforceAlternating(lines) {
                 });
         },
 
-        startLongPress() {
+        startLongPress(e) {
+            const target = e.target;
             this.longPressTimer = setTimeout(() => {
-                this.handleTextSelection();
+                if (target.classList?.contains('lyric-text') && target.textContent.trim() === '') {
+                    target.focus();
+                    this.addSectionModal?.classList.add('visible');
+                } else {
+                    this.handleTextSelection();
+                }
             }, 600);
         },
 
@@ -1084,6 +1090,7 @@ function enforceAlternating(lines) {
             this.updateReadOnlyState();
             this.updateChordsVisibility();
             this.updateSyllableCount();
+            this.autoNumberVerses();
         },
 
         insertSectionAtCursor(label) {
@@ -1106,14 +1113,23 @@ function enforceAlternating(lines) {
                 node = node.parentElement;
             }
             const currentSection = node?.closest?.('.section');
+            let lineGroup = null;
             if (currentSection) {
                 this.lyricsDisplay.insertBefore(section, currentSection.nextSibling);
             } else {
-                const lineGroup = node?.closest?.('.lyrics-line-group');
+                lineGroup = node?.closest?.('.lyrics-line-group');
                 if (lineGroup) {
                     this.lyricsDisplay.insertBefore(section, lineGroup);
                 } else {
                     this.lyricsDisplay.appendChild(section);
+                }
+            }
+
+            if (lineGroup) {
+                const lyric = lineGroup.querySelector('.lyric-text')?.textContent.trim();
+                const chord = lineGroup.querySelector('.chord-line')?.textContent.trim();
+                if (lyric === '' && chord === '') {
+                    lineGroup.remove();
                 }
             }
 
@@ -1211,6 +1227,63 @@ function enforceAlternating(lines) {
             });
         },
 
+        autoNumberVerses() {
+            let count = 0;
+            this.lyricsDisplay.querySelectorAll('.section-label').forEach(label => {
+                const text = label.textContent.trim();
+                if (/^\[verse(\s*\d*)?\]$/i.test(text)) {
+                    count++;
+                    label.textContent = `[Verse ${count}]`;
+                }
+            });
+        },
+
+        convertBracketSections() {
+            const texts = Array.from(this.lyricsDisplay.querySelectorAll('.lyric-text'));
+            texts.forEach(textEl => {
+                const text = textEl.textContent.trim();
+                if (!/^\[.*\]$/.test(text)) return;
+
+                const lineGroup = textEl.closest('.lyrics-line-group');
+                if (!lineGroup) return;
+
+                const parentSection = lineGroup.closest('.section');
+                const section = document.createElement('div');
+                section.className = 'section';
+
+                const header = document.createElement('div');
+                header.className = 'lyrics-line section-label';
+                header.textContent = text;
+                header.setAttribute('contenteditable', !this.isReadOnly);
+                header.addEventListener('click', () => section.classList.toggle('collapsed'));
+                header.addEventListener('input', () => this.handleLyricsInput());
+                section.appendChild(header);
+
+                const content = document.createElement('div');
+                content.className = 'section-content';
+                section.appendChild(content);
+
+                let next = lineGroup.nextSibling;
+                const container = lineGroup.parentElement;
+                while (next && next.classList && next.classList.contains('lyrics-line-group')) {
+                    const nextText = next.querySelector('.lyric-text')?.textContent.trim();
+                    if (nextText && /^\[.*\]$/.test(nextText)) break;
+                    const temp = next;
+                    next = next.nextSibling;
+                    content.appendChild(temp);
+                }
+
+                if (parentSection) {
+                    this.lyricsDisplay.insertBefore(section, parentSection.nextSibling);
+                } else {
+                    this.lyricsDisplay.insertBefore(section, lineGroup);
+                }
+
+                lineGroup.remove();
+            });
+            this.initSectionDrag();
+        },
+
         findRhymes(lines) {
             const rhymeWords = lines.map(line => {
                 if (/^\[.*\]$/.test(line.trim())) return '';
@@ -1261,6 +1334,8 @@ function enforceAlternating(lines) {
         handleLyricsInput() {
             this.hasUnsavedChanges = true;
             this.trimDomEmptyLines();
+            this.convertBracketSections();
+            this.autoNumberVerses();
             this.saveCurrentSong();
         },
 


### PR DESCRIPTION
## Summary
- Keep editor header visible with sticky positioning
- Convert bracketed lines to draggable sections and auto-number verses
- Allow long-pressing empty lyric lines to quickly insert section labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689da2e5f65c832ab50758bea7e63750