### PR TITLE
Refactor editor header and fix JS errors

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -21,60 +21,92 @@
     overflow-y: auto;
 }
 
-.editor-header {
+/* Header layout */
+#app-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 0.1em 0.1em;
-    font-size: 0.92em;
-    min-height: unset;
-    background-color: var(--bg-secondary);
-    border-bottom: 1px solid var(--border);
-    transition: all 0.3s ease-in-out;
-    border-radius: 0 0 1rem 1rem;
-    box-shadow: 0 2px 12px rgba(0,0,0,0.08);
-    backdrop-filter: blur(6px);
-    margin: 0;
-    width: 100%;
+    background: #1e1e1e;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-bottom: 2px solid #333;
     position: sticky;
     top: 0;
     z-index: 1000;
 }
 
-.editor-header h2,
-.editor-header .song-info h2 {
+#app-header .header-left,
+#app-header .header-right {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+#app-title {
+    font-size: 1.2rem;
     margin: 0;
-    font-size: 1.25em;
-    line-height: 1.1;
-    font-weight: bold;
 }
 
-.editor-header {
+#save-status {
+    font-size: 0.85rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+#save-status.visible {
+    opacity: 1;
+}
+
+#save-status.unsaved {
+    color: var(--warning);
+}
+
+#song-edited {
+    font-size: 0.75rem;
+    color: #aaa;
+}
+
+/* Font controls in header */
+#font-controls {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 0.75em 1em;
-    gap: 1em;
+    gap: 0.25rem;
+    background: #2c2c2c;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
 }
 
-.editor-control-group {
-    display: flex;
-    align-items: center;
-    flex-wrap: nowrap;
-    gap: 1.25rem;
-    padding: 0.5rem;
-    border-radius: 0.75rem;
-    background: var(--bg-tertiary-transparent);
-    backdrop-filter: blur(4px);
+#font-controls button {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0 0.4rem;
+    transition: background 0.2s;
 }
 
-.editor-control-group.left-controls {
-    margin-left: 0.5rem;
-    box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+#font-controls button:hover {
+    background: #444;
 }
 
-.editor-control-group.right-controls {
-    margin-right: 0.5rem;
+#font-size-display {
+    min-width: 2.5rem;
+    text-align: center;
+    font-size: 0.9rem;
+    color: #ccc;
+}
+
+/* Responsive tweaks */
+@media (max-width: 600px) {
+    #app-header {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    #app-header .header-right {
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
 }
 
 
@@ -104,22 +136,6 @@
 .song-title-card:hover {
     transform: translateX(-50%) scale(1.03);
     box-shadow: 0 6px 24px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.05);
-}
-
-.font-size-card {
-    position: fixed;
-    bottom: 2rem;
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--bg-tertiary);
-    padding: 0.5rem 1rem;
-    border-radius: 1.5rem;
-    box-shadow: 0 4px 20px rgba(0,0,0,0.1), 0 0 0 1px rgba(0,0,0,0.04);
-    z-index: 999;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--text-primary);
 }
 
 
@@ -620,23 +636,10 @@
     flex-direction: column;
     gap: 1rem;
   }
-  .editor-header {
-    padding: 0.3em 0.5em;
-    font-size: 0.8em;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: 0.5em;
-  }
-
   .song-title-card {
     top: 4em;
     font-size: 1em;
     padding: 0.3em 0.8em;
-  }
-
-  .editor-control-group {
-    gap: 0.7em;
-    flex-wrap: nowrap;
   }
 
   #lyrics-display {

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -55,30 +55,6 @@
             color: var(--accent-primary);
         }
         
-        .save-status {
-            position: fixed;
-            top: 1rem;
-            left: 50%;
-            transform: translateX(-50%);
-            background: var(--bg-tertiary);
-            color: var(--text-secondary);
-            padding: 0.5rem 1rem;
-            border-radius: var(--border-radius-base);
-            font-size: 0.9rem;
-            opacity: 0;
-            transition: opacity 0.3s ease;
-            z-index: 998;
-        }
-        
-        .save-status.visible {
-            opacity: 1;
-        }
-        
-        .save-status.unsaved {
-            background: var(--warning);
-            color: var(--bg-primary);
-        }
-        
         @media (max-width: 800px) {
             .metadata-panel {
                 width: 100%;
@@ -90,29 +66,32 @@
 <body>
 
     <div id="editor-mode" class="editor-mode-overlay">
-        <!-- Save Status Indicator -->
-        <div id="save-status" class="save-status">
-            All changes saved
-        </div>
-
-        <div class="editor-header">
-            <div class="editor-control-group left-controls">
+        <header id="app-header">
+            <div class="header-left">
+                <h1 id="app-title">LyricSmith</h1>
+                <div id="save-status"></div>
+                <span id="song-edited"></span>
+            </div>
+            <div class="header-right">
                 <button id="editor-menu-btn" class="btn icon-btn" title="Editor Menu">
                     <i class="fas fa-ellipsis-h"></i>
                 </button>
                 <button id="add-section-btn" class="btn icon-btn" title="Add Section">
                     <i class="fas fa-plus"></i>
                 </button>
-            </div>
-            <div class="editor-control-group right-controls">
                 <button id="ai-tools-btn" class="btn icon-btn" title="AI Tools">
                     <i class="fas fa-robot"></i>
                 </button>
                 <button id="exit-editor-btn" class="btn icon-btn" title="Exit Editor">
                     <i class="fas fa-times"></i>
                 </button>
+                <div id="font-controls">
+                    <button id="font-decrease" title="Decrease Font Size">A−</button>
+                    <span id="font-size-display">100%</span>
+                    <button id="font-increase" title="Increase Font Size">A+</button>
+                </div>
             </div>
-        </div>
+        </header>
 
         <div id="song-title-card" class="song-title-card"></div>
 
@@ -121,16 +100,6 @@
 
             <!-- Enhanced Copy Button with Dropdown -->
 
-        </div>
-
-        <div id="font-size-card" class="font-size-card">
-            <button id="decrease-font-btn" class="btn icon-btn" title="Decrease Font Size">
-                <i class="fas fa-minus"></i>
-            </button>
-            <span id="font-size-display" class="font-size-display"></span>
-            <button id="increase-font-btn" class="btn icon-btn" title="Increase Font Size">
-                <i class="fas fa-plus"></i>
-            </button>
         </div>
 
         <div id="ai-context-menu" class="ai-context-menu">
@@ -287,7 +256,7 @@
             
             <div class="metadata-row">
                 <label>Last Edited:</label>
-                <span id="song-edited" class="metadata-info"></span>
+                <span id="song-edited-meta" class="metadata-info"></span>
             </div>
             
             <div class="metadata-row">

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -193,8 +193,8 @@ function enforceAlternating(lines) {
         editorMode: document.getElementById('editor-mode'),
         lyricsEditorContainer: document.getElementById('lyrics-editor-container'),
         lyricsDisplay: document.getElementById('lyrics-display'),
-        decreaseFontBtn: document.getElementById('decrease-font-btn'),
-        increaseFontBtn: document.getElementById('increase-font-btn'),
+        decreaseFontBtn: document.getElementById('font-decrease'),
+        increaseFontBtn: document.getElementById('font-increase'),
         fontSizeDisplay: document.getElementById('font-size-display'),
         toggleThemeBtn: document.getElementById('theme-toggle-btn'),
         exitEditorBtn: document.getElementById('exit-editor-btn'),
@@ -260,29 +260,7 @@ function enforceAlternating(lines) {
             this.loadData();
             this.loadAISettings();
             this.setupEventListeners();
-            this.debouncedSaveCurrentSong = debounce(() => this.
-showSaveStatus(state = 'saved') {
-    const el = document.getElementById('save-status');
-    if (!el) return;
-    el.classList.add('visible');
-    if (state === 'unsaved') { el.textContent = 'Unsaved changes'; el.classList.add('unsaved'); }
-    if (state === 'saving')  { el.textContent = 'Saving…'; el.classList.add('unsaved'); }
-    if (state === 'saved')   { el.textContent = 'All changes saved'; el.classList.remove('unsaved'); }
-    if (state === 'error')   { el.textContent = 'Save failed'; el.classList.add('unsaved'); }
-    clearTimeout(this._saveStatusTimer);
-    this._saveStatusTimer = setTimeout(() => { el.classList.remove('visible'); }, 2000);
-},
-safeLocalStorageSet(key, value) {
-    try {
-        localStorage.setItem(key, value);
-        return true;
-    } catch (e) {
-        console.warn('localStorage write failed', e);
-        ClipboardManager?.showToast?.('Storage full or blocked', 'error');
-        return false;
-    }
-},
-saveCurrentSong(false), 500);
+            this.debouncedSaveCurrentSong = debounce(() => this.saveCurrentSong(false), 500);
             this.loadEditorState();
             if (this.editModeSelect) {
                 this.editModeSelect.value = this.editMode;
@@ -291,13 +269,40 @@ saveCurrentSong(false), 500);
                 this.rhymeModeToggle.checked = this.isRhymeMode;
             }
             this.displayCurrentEditorSong();
-            window.addEventListener('beforeunload', (e) => { if (this.hasUnsavedChanges) { e.preventDefault(); e.returnValue = ''; }});
+            window.addEventListener('beforeunload', (e) => {
+                if (this.hasUnsavedChanges) {
+                    e.preventDefault();
+                    e.returnValue = '';
+                }
+            });
 
             this.setupResizeObserver();
             this.isChordsVisible = window.CONFIG.chordsModeEnabled;
             this.updateChordsVisibility();
         },
 
+        showSaveStatus(state = 'saved') {
+            const el = document.getElementById('save-status');
+            if (!el) return;
+            el.classList.add('visible');
+            if (state === 'unsaved') { el.textContent = 'Unsaved changes'; el.classList.add('unsaved'); }
+            if (state === 'saving')  { el.textContent = 'Saving…'; el.classList.add('unsaved'); }
+            if (state === 'saved')   { el.textContent = 'All changes saved'; el.classList.remove('unsaved'); }
+            if (state === 'error')   { el.textContent = 'Save failed'; el.classList.add('unsaved'); }
+            clearTimeout(this._saveStatusTimer);
+            this._saveStatusTimer = setTimeout(() => { el.classList.remove('visible'); }, 2000);
+        },
+
+        safeLocalStorageSet(key, value) {
+            try {
+                localStorage.setItem(key, value);
+                return true;
+            } catch (e) {
+                console.warn('localStorage write failed', e);
+                ClipboardManager?.showToast?.('Storage full or blocked', 'error');
+                return false;
+            }
+        },
         loadData() {
             this.songs = JSON.parse(localStorage.getItem('songs')) || [];
             const theme = localStorage.getItem('theme') || 'dark';
@@ -979,16 +984,17 @@ saveCurrentSong(isExplicit = false) {
                 }
             });
 
-            const lyrics = this.trimExtraEmptyLines(lyricLines.join('
-'));
-            const chords = this.trimExtraEmptyLines(chordLines.join('
-'));
+            const lyrics = this.trimExtraEmptyLines(lyricLines.join('\n'));
+            const chords = this.trimExtraEmptyLines(chordLines.join('\n'));
 
             this.currentSong.lyrics = this.normalizeSectionLabels(lyrics);
             this.currentSong.chords = chords;
             this.currentSong.lastEditedAt = new Date().toISOString();
+            const editedText = new Date(this.currentSong.lastEditedAt).toLocaleString();
             const editedEl = document.getElementById('song-edited');
-            if (editedEl) editedEl.textContent = new Date(this.currentSong.lastEditedAt).toLocaleString();
+            const editedMetaEl = document.getElementById('song-edited-meta');
+            if (editedEl) editedEl.textContent = editedText;
+            if (editedMetaEl) editedMetaEl.textContent = editedText;
 
             const songIndex = this.songs.findIndex(s => s.id === this.currentSong.id);
             if (songIndex !== -1) {
@@ -1006,27 +1012,6 @@ saveCurrentSong(isExplicit = false) {
             this.showSaveStatus('error');
         }
     },
-;
-
-            const lyrics = this.trimExtraEmptyLines(lyricLines.join('\n'));
-            const chords = this.trimExtraEmptyLines(chordLines.join('\n'));
-
-            this.currentSong.lyrics = this.normalizeSectionLabels(lyrics);
-            this.currentSong.chords = chords;
-            this.currentSong.lastEditedAt = new Date().toISOString();
-            document.getElementById('song-edited').textContent = new Date(this.currentSong.lastEditedAt).toLocaleString();
-
-            const songIndex = this.songs.findIndex(s => s.id === this.currentSong.id);
-            if (songIndex !== -1) {
-                this.songs[songIndex] = this.currentSong;
-                localStorage.setItem('songs', JSON.stringify(this.songs));
-                this.hasUnsavedChanges = false;
-                
-                if (isExplicit) {
-                    ClipboardManager.showToast('Song saved!', 'success');
-                }
-            }
-        },
 
         displayCurrentEditorSong() {
             if (this.currentEditorSongIndex === -1) return;
@@ -1044,7 +1029,7 @@ saveCurrentSong(isExplicit = false) {
             this.fontSize = this.perSongFontSizes[this.currentSong.id] || 16;
 
             document.getElementById('song-title-card').textContent = this.currentSong.title;
-            this.fontSizeDisplay.textContent = `${this.fontSize}px`;
+            this.fontSizeDisplay.textContent = `${Math.round((this.fontSize / 16) * 100)}%`;
 
             const mm = localStorage.getItem(`measureMode_${this.currentSong.id}`);
             this.isMeasureMode = mm === '1';
@@ -1058,7 +1043,11 @@ saveCurrentSong(isExplicit = false) {
             document.getElementById('song-tags').value = this.currentSong.tags.join(', ');
             document.getElementById('song-notes').value = this.currentSong.notes || '';
             document.getElementById('song-created').textContent = new Date(this.currentSong.createdAt).toLocaleString();
-            document.getElementById('song-edited').textContent = new Date(this.currentSong.lastEditedAt).toLocaleString();
+            const editedText = new Date(this.currentSong.lastEditedAt).toLocaleString();
+            const headerEdited = document.getElementById('song-edited');
+            const metaEdited = document.getElementById('song-edited-meta');
+            if (headerEdited) headerEdited.textContent = editedText;
+            if (metaEdited) metaEdited.textContent = editedText;
 
             this.currentSong.lyrics = this.normalizeSectionLabels(this.currentSong.lyrics || '');
 
@@ -1451,7 +1440,7 @@ saveCurrentSong(isExplicit = false) {
             this.perSongFontSizes[this.currentSong.id] = this.fontSize;
             localStorage.setItem('perSongFontSizes', JSON.stringify(this.perSongFontSizes));
             this.lyricsDisplay.style.fontSize = `${this.fontSize}px`;
-            this.fontSizeDisplay.textContent = `${this.fontSize}px`;
+            this.fontSizeDisplay.textContent = `${Math.round((this.fontSize / 16) * 100)}%`;
         },
 
         navigateSong(direction) {


### PR DESCRIPTION
## Summary
- Move font size controls to new app header and show save status there
- Style header as a responsive flex bar with integrated font controls
- Repair editor JavaScript initialization and update font control IDs

## Testing
- `node --check editor/editor.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f3213c2a0832abc51067a1a98009a