### PR TITLE
Improve editor header controls and song list padding

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -27,7 +27,7 @@
     justify-content: space-between;
     align-items: center;
     background: var(--gradient-primary);
-    color: var(--bg-primary);
+    color: var(--text-primary);
     padding: 0.5rem 1rem;
     border-bottom: 1px solid var(--border-light);
     position: sticky;
@@ -107,6 +107,16 @@
     #app-header .header-right {
         flex-wrap: wrap;
         gap: 0.5rem;
+    }
+    .btn.icon-btn {
+        width: 2.2rem;
+        height: 2.2rem;
+    }
+    #font-controls button {
+        font-size: 1.1rem;
+    }
+    #font-size-display {
+        font-size: 1rem;
     }
 }
 

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -93,6 +93,9 @@
                 <button id="ai-tools-btn" class="btn icon-btn" title="AI Tools">
                     <i class="fas fa-robot"></i>
                 </button>
+                <button id="theme-toggle-btn" class="btn icon-btn" title="Toggle Theme">
+                    <i class="fas fa-adjust"></i>
+                </button>
                 <button id="exit-editor-btn" class="btn icon-btn" title="Exit Editor">
                     <i class="fas fa-times"></i>
                 </button>

--- a/style.css
+++ b/style.css
@@ -1193,6 +1193,7 @@ html, body {
     font-size: 1.1rem;
     color: var(--text-primary);
     margin-bottom: 0.25rem;
+    padding: 0 0.25rem;
 }
 
 .song-metadata {


### PR DESCRIPTION
## Summary
- Ensure song title contrasts against editor header background
- Resize mobile header buttons while enlarging font size controls
- Add theme toggle button and slight padding for song titles in list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57ff94b98832a82b41eec6bb94d12