### PR TITLE
feat: modernize UI with refreshed theme

### DIFF
--- a/editor/editor.css
+++ b/editor/editor.css
@@ -870,10 +870,3 @@
 #ryhme-mode-toggle {
     margin-left: 5rem;
 }
-
-.btn.icon-btn {
-    width: 2.5rem;
-    height: 2.5rem;
-    padding: 0;
-    border-radius: 50%;
-}

--- a/editor/editor.html
+++ b/editor/editor.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="editor.css">
     <link rel="icon" href="../assets/icons/icon-192x192.png">
     <link rel="manifest" href="../manifest.webmanifest">
+    <meta name="theme-color" content="#00bcd4">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -7,9 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <link rel="stylesheet" href="../style.css" />
   <link rel="manifest" href="../manifest.webmanifest" />
-  <meta name="theme-color" content="#000000" />
+  <meta name="theme-color" content="#00bcd4" />
   <link rel="icon" href="../assets/icons/icon-192x192.png" />
-  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Neonderthaw&display=swap" rel="stylesheet" />
@@ -86,23 +86,17 @@
     }
 
     .hub-card {
-      background: var(--bg-tertiary);
-      border: 1px solid var(--border-light);
-      border-radius: var(--border-radius-base);
-      box-shadow: var(--shadow-sm);
       padding: 1.1rem;
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
-      transition: transform .15s ease, box-shadow .2s ease, background .2s ease, border-color .2s ease;
       cursor: pointer;
       position: relative;
       overflow: hidden;
+      transition: transform .15s ease, border-color .2s ease;
     }
     .hub-card:hover {
       transform: translateY(-2px);
-      box-shadow: var(--shadow-lg);
-      background: var(--bg-hover);
       border-color: var(--accent-primary);
     }
     .hub-card i {
@@ -123,16 +117,8 @@
     .hub-card .go {
       margin-top: 0.25rem;
       align-self: flex-start;
-      background: var(--accent-primary);
-      color: var(--bg-primary);
-      border: none;
-      border-radius: 999px;
-      padding: 0.4rem 0.75rem;
-      font-size: 0.9rem;
-      box-shadow: var(--shadow-sm);
     }
     .hub-card .go:hover {
-      background: var(--accent-hover);
       box-shadow: var(--shadow-md);
     }
 
@@ -155,11 +141,6 @@
     }
     .modal-overlay.visible { opacity: 1; pointer-events: auto; }
     .modal {
-      background: var(--bg-secondary);
-      color: var(--text-primary);
-      border: 1px solid var(--border);
-      border-radius: var(--border-radius-base);
-      box-shadow: var(--shadow-lg);
       width: min(640px, 92vw);
       padding: 1rem;
       display: grid;
@@ -174,11 +155,6 @@
     .modal input[type="text"],
     .modal textarea {
       width: 100%;
-      border-radius: var(--border-radius-base);
-      border: 1px solid var(--border);
-      background: var(--bg-tertiary);
-      color: var(--text-primary);
-      padding: .6rem .7rem;
     }
     .modal textarea { min-height: 120px; resize: vertical; }
 
@@ -187,16 +163,13 @@
       justify-content: space-between;
       margin-top: .25rem;
     }
-    .btn {
-      background: var(--accent-primary);
-      color: var(--bg-primary);
-      border: none; border-radius: var(--border-radius-base);
-      padding: .55rem .9rem; cursor: pointer; box-shadow: var(--shadow-sm);
-    }
-    .btn:hover { background: var(--accent-hover); box-shadow: var(--shadow-md); }
     .btn.ghost {
-      background: transparent; color: var(--text-secondary);
+      background: transparent;
+      color: var(--text-secondary);
       border: 1px solid var(--border);
+    }
+    .btn.ghost:hover {
+      background: var(--bg-hover);
     }
     .btn.danger { background: var(--danger); color: #fff; }
     .hint { color: var(--text-muted); font-size: .9rem; }
@@ -246,35 +219,35 @@
 
       <section class="hub-grid">
         <!-- 1. MuseDice -->
-        <a class="hub-card" href="musedice.html">
+        <a class="hub-card card" href="musedice.html">
           <i class="fas fa-dice"></i>
           <h3>MuseDice</h3>
           <p>Roll creative seeds: moods, metaphors, images, and lines to spark songs.</p>
-          <button class="go">Open</button>
+          <button class="btn go">Open</button>
         </a>
 
         <!-- 2. Suno Prompt Engine -->
-        <a class="hub-card" href="sunopromptengine.html">
+        <a class="hub-card card" href="sunopromptengine.html">
           <i class="fas fa-music"></i>
           <h3>Suno Prompt Engine</h3>
           <p>Turn your lyrics into Suno-ready prompts with structured guidance.</p>
-          <button class="go">Open</button>
+          <button class="btn go">Open</button>
         </a>
 
         <!-- 3. Create New Song -->
-        <button id="create-song-card" class="hub-card" type="button">
+        <button id="create-song-card" class="hub-card card" type="button">
           <i class="fas fa-pen-nib"></i>
           <h3>Create New Song</h3>
           <p>Blank slate in the editor with section scaffolding ready to go.</p>
-          <span class="go">Start</span>
+          <span class="btn go">Start</span>
         </button>
 
         <!-- 4. Settings -->
-        <button id="open-settings" class="hub-card" type="button">
+        <button id="open-settings" class="hub-card card" type="button">
           <i class="fas fa-cog"></i>
           <h3>Settings</h3>
           <p>Set your OpenRouter key & model, custom system prompt, and manage export/import.</p>
-          <span class="go">Configure</span>
+          <span class="btn go">Configure</span>
         </button>
       </section>
     </main>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -5,8 +5,8 @@
   "start_url": "index.html",
   "display": "standalone",
   "orientation": "portrait",
-  "background_color": "#0d0004",
-  "theme_color": "#0d0004",
+  "background_color": "#121212",
+  "theme_color": "#00bcd4",
   "icons": [
     { "src": "assets/icons/icon-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "assets/icons/icon-512x512.png", "sizes": "512x512", "type": "image/png" }

--- a/script.js
+++ b/script.js
@@ -12,8 +12,21 @@ document.addEventListener('DOMContentLoaded', () => {
     { passive: false }
   );
   // === THEME TOGGLE ===
-  const savedTheme = localStorage.getItem('theme') || 'dark';
-  document.documentElement.dataset.theme = savedTheme;
+  const savedTheme = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const defaultTheme = savedTheme || (prefersDark ? 'dark' : 'light');
+  document.documentElement.dataset.theme = defaultTheme;
+  updateThemeButton(defaultTheme);
+
+  function updateThemeButton(theme) {
+    const btn = document.getElementById('theme-toggle-btn');
+    if (btn) {
+      btn.setAttribute(
+        'aria-label',
+        theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+      );
+    }
+  }
 
   function attachThemeToggle() {
     const themeToggleBtn = document.getElementById('theme-toggle-btn');
@@ -21,6 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const newTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
       document.documentElement.dataset.theme = newTheme;
       localStorage.setItem('theme', newTheme);
+      updateThemeButton(newTheme);
     });
   }
   attachThemeToggle();

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
 /* ========================================
     Global Layout Constants & Transitions
     ======================================== */
@@ -6,98 +8,98 @@
     --tab-button-height: 52px;
     --padding-base: 1.5rem;
     --border-radius-base: 1rem;
-    --transition-speed: 0.3s ease-in-out;
+    --transition-speed: 0.25s ease-in-out;
 }
 
 /* ========================================
     Theme Definitions
     ======================================== */
 /* ========================================
-   RED DARK THEME
+   TEAL DARK THEME
    ======================================== */
 :root,
 [data-theme="dark"],
 [data-theme="amoled-dark"] {
     /* Background Colors */
-    --bg-primary: #0d0004;
-    --bg-secondary: #1a0c0e;
-    --bg-tertiary: #5e0010;
-    --bg-hover: #7a0212;
-    --bg-active: #9e001c;
+    --bg-primary: #121212;
+    --bg-secondary: #1e1e1e;
+    --bg-tertiary: #2a2a2a;
+    --bg-hover: #333333;
+    --bg-active: #3d3d3d;
 
     /* Text Colors */
-    --text-primary: #fdfbfa;
-    --text-secondary: #b89a9f;
-    --text-muted: #885e66;
+    --text-primary: #e0e0e0;
+    --text-secondary: #b3b3b3;
+    --text-muted: #888888;
 
     /* Accent Colors */
-    --accent-primary: #c1001f;
-    --accent-secondary: #e52e3b;
-    --accent-hover: #ff475a;
-    --accent-active: #7a0212;
-    --accent-glow: rgba(255, 71, 90, 0.3);
+    --accent-primary: #00bcd4;
+    --accent-secondary: #26c6da;
+    --accent-hover: #00acc1;
+    --accent-active: #0097a7;
+    --accent-glow: rgba(0, 188, 212, 0.3);
 
     /* Borders */
-    --border: #9e001c;
-    --border-light: #b89a9f;
+    --border: #3d3d3d;
+    --border-light: #4a4a4a;
 
     /* Shadows */
-    --shadow-sm: 0 1px 3px rgba(255, 71, 90, 0.05), 0 1px 2px rgba(255, 71, 90, 0.1);
-    --shadow-md: 0 4px 6px rgba(255, 71, 90, 0.1), 0 1px 3px rgba(255, 71, 90, 0.05);
-    --shadow-lg: 0 10px 25px rgba(255, 71, 90, 0.1), 0 5px 10px rgba(255, 71, 90, 0.05);
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.2);
+    --shadow-md: 0 4px 8px rgba(0,0,0,0.25);
+    --shadow-lg: 0 10px 15px rgba(0,0,0,0.3);
 
     /* Status Colors */
-    --success: #00e600;
-    --warning: #e6e600;
-    --danger: #e60000;
-    --info: #00cccc;
+    --success: #4caf50;
+    --warning: #ff9800;
+    --danger: #f44336;
+    --info: #2196f3;
 
     /* Gradients */
-    --gradient-primary: linear-gradient(135deg, #0d0004 0%, #1a0c0e 100%);
-    --gradient-accent: linear-gradient(135deg, #c1001f 0%, #e52e3b 100%);
+    --gradient-primary: linear-gradient(135deg, #1e1e1e 0%, #121212 100%);
+    --gradient-accent: linear-gradient(135deg, #00bcd4 0%, #26c6da 100%);
 }
 
 /* ========================================
-   RED LIGHT THEME
+   TEAL LIGHT THEME
    ======================================== */
 [data-theme="light"] {
     /* Background Colors */
-    --bg-primary: #fdfbfa;
-    --bg-secondary: #f0dada;
-    --bg-tertiary: #f7d0d0;
-    --bg-hover: #ffc0c0;
-    --bg-active: #ffaaaa;
+    --bg-primary: #ffffff;
+    --bg-secondary: #f5f5f5;
+    --bg-tertiary: #e9ecef;
+    --bg-hover: #e2e6ea;
+    --bg-active: #dae0e5;
 
     /* Text Colors */
-    --text-primary: #0d0004;
-    --text-secondary: #5e0010;
-    --text-muted: #9e001c;
+    --text-primary: #212529;
+    --text-secondary: #495057;
+    --text-muted: #6c757d;
 
     /* Accent Colors */
-    --accent-primary: #c1001f;
-    --accent-secondary: #9e001c;
-    --accent-hover: #7a0212;
-    --accent-active: #e52e3b;
-    --accent-glow: rgba(193, 0, 31, 0.3);
+    --accent-primary: #00bcd4;
+    --accent-secondary: #0097a7;
+    --accent-hover: #00acc1;
+    --accent-active: #00838f;
+    --accent-glow: rgba(0, 188, 212, 0.25);
 
     /* Borders */
-    --border: #b89a9f;
-    --border-light: #dcafb0;
+    --border: #ced4da;
+    --border-light: #dee2e6;
 
     /* Shadows */
-    --shadow-sm: 0 1px 3px rgba(193, 0, 31, 0.12), 0 1px 2px rgba(193, 0, 31, 0.24);
-    --shadow-md: 0 4px 6px rgba(193, 0, 31, 0.1), 0 1px 3px rgba(193, 0, 31, 0.08);
-    --shadow-lg: 0 10px 25px rgba(193, 0, 31, 0.1), 0 5px 10px rgba(193, 0, 31, 0.05);
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+    --shadow-lg: 0 10px 20px rgba(0,0,0,0.15);
 
     /* Status Colors */
-    --success: #008000;
-    --warning: #cc9900;
-    --danger: #cc0000;
-    --info: #006666;
+    --success: #2e7d32;
+    --warning: #ed6c02;
+    --danger: #d32f2f;
+    --info: #0288d1;
 
     /* Gradients */
-    --gradient-primary: linear-gradient(135deg, #fdfbfa 0%, #f0dada 100%);
-    --gradient-accent: linear-gradient(135deg, #c1001f 0%, #9e001c 100%);
+    --gradient-primary: linear-gradient(135deg, #ffffff 0%, #f5f5f5 100%);
+    --gradient-accent: linear-gradient(135deg, #00bcd4 0%, #0097a7 100%);
 }
 
 
@@ -106,11 +108,12 @@
     Base & Global Styles
     ======================================== */
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     background-color: var(--bg-primary);
     color: var(--text-primary);
     margin: 0;
     font-size: 1rem;
+    line-height: 1.5;
     transition: background-color var(--transition-speed), color var(--transition-speed);
     overflow-x: hidden; /* Prevent horizontal scrolling */
     box-sizing: border-box; /* Include padding and border in the element's total width and height */
@@ -145,6 +148,61 @@ mark {
     width: 100%;
     max-width: 100%;
     box-sizing: border-box;
+}
+
+/* ========================================
+   Utility Components
+   ======================================== */
+.card {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border-light);
+    border-radius: var(--border-radius-base);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--transition-speed), transform var(--transition-speed), background var(--transition-speed);
+}
+
+.card:hover {
+    box-shadow: var(--shadow-lg);
+    transform: translateY(-2px);
+    background: var(--bg-hover);
+}
+
+input[type="text"],
+input[type="number"],
+textarea,
+select {
+    border-radius: var(--border-radius-base);
+    border: 1px solid var(--border);
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    padding: 0.5rem 0.75rem;
+    transition: border-color var(--transition-speed), box-shadow var(--transition-speed), background var(--transition-speed);
+}
+
+input:focus,
+input[type="number"]:focus,
+textarea:focus,
+select:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 2px var(--accent-glow);
+    background: var(--bg-secondary);
+}
+
+.modal {
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    border-radius: var(--border-radius-base);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    transform: scale(0.95);
+    opacity: 0;
+    transition: opacity var(--transition-speed), transform var(--transition-speed);
+}
+
+.modal.show {
+    transform: scale(1);
+    opacity: 1;
 }
 
 /* ========================================


### PR DESCRIPTION
## Summary
- apply teal-based light/dark themes and Inter font for a cleaner look
- add reusable card, input and modal styles with subtle shadows and rounded corners
- make theme toggle accessible and respect system preference
- align hub and editor pages with refreshed theme colors and shared button styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c07e0a04832a98713c1f9df0dd2c