### PR TITLE
Swap text buttons for Font Awesome icons

### DIFF
--- a/editor/editor.html
+++ b/editor/editor.html
@@ -111,17 +111,17 @@
         </div>
 
         <div id="ai-context-menu" class="ai-context-menu">
-            <button data-action="rhyme"><i class="fas fa-bullseye"></i> Rhyme</button>
-            <button data-action="reword"><i class="fas fa-sync"></i> Reword</button>
-            <button data-action="rewrite"><i class="fas fa-pen"></i> Rewrite</button>
-            <button data-action="continue"><i class="fas fa-lightbulb"></i> Continue</button>
+            <button data-action="rhyme" title="Rhyme"><i class="fas fa-bullseye"></i></button>
+            <button data-action="reword" title="Reword"><i class="fas fa-sync"></i></button>
+            <button data-action="rewrite" title="Rewrite"><i class="fas fa-pen"></i></button>
+            <button data-action="continue" title="Continue"><i class="fas fa-lightbulb"></i></button>
             <button id="ai-menu-close" class="ai-menu-close"><i class="fas fa-times"></i></button>
         </div>
 
         <div id="section-menu" class="section-menu">
-            <button data-action="rename"><i class="fas fa-i-cursor"></i> Rename</button>
-            <button data-action="delete-label"><i class="fas fa-tag"></i> Delete Label</button>
-            <button data-action="delete-section"><i class="fas fa-trash"></i> Delete Label + Lyrics</button>
+            <button data-action="rename" title="Rename"><i class="fas fa-i-cursor"></i></button>
+            <button data-action="delete-label" title="Delete Label"><i class="fas fa-tag"></i></button>
+            <button data-action="delete-section" title="Delete Label + Lyrics"><i class="fas fa-trash"></i></button>
             <button id="section-menu-close" class="section-menu-close"><i class="fas fa-times"></i></button>
         </div>
         
@@ -133,20 +133,20 @@
     <div id="copy-modal" class="modal-overlay">
       <div class="modal">
         <h2>Copy Options</h2>
-        <button class="modal-copy-btn" data-copy-type="raw"><i class="fas fa-align-left"></i> Raw Lyrics</button>
-        <button class="modal-copy-btn" data-copy-type="chords"><i class="fas fa-guitar"></i> Lyrics + Chords</button>
-        <button class="modal-copy-btn" data-copy-type="formatted"><i class="fas fa-file-alt"></i> Full Song (Markdown)</button>
-        <button class="modal-copy-btn" data-copy-type="metadata"><i class="fas fa-info-circle"></i> Metadata Only</button>
-        <button class="modal-copy-btn" data-copy-type="download"><i class="fas fa-download"></i> Download as TXT</button>
-        <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
+        <button class="modal-copy-btn" data-copy-type="raw" title="Raw Lyrics"><i class="fas fa-align-left"></i></button>
+        <button class="modal-copy-btn" data-copy-type="chords" title="Lyrics + Chords"><i class="fas fa-guitar"></i></button>
+        <button class="modal-copy-btn" data-copy-type="formatted" title="Full Song (Markdown)"><i class="fas fa-file-alt"></i></button>
+        <button class="modal-copy-btn" data-copy-type="metadata" title="Metadata Only"><i class="fas fa-info-circle"></i></button>
+        <button class="modal-copy-btn" data-copy-type="download" title="Download as TXT"><i class="fas fa-download"></i></button>
+        <button class="close-modal-btn" title="Close"><i class="fas fa-times"></i></button>
       </div>
     </div>
 
     <div id="editor-modal" class="modal-overlay">
       <div class="modal">
         <h2>Editor Options</h2>
-        <button id="toggle-chords-btn" class="modal-action-btn"><i class="fas fa-guitar"></i> Toggle Chords</button>
-        <button id="toggle-read-only-btn" class="modal-action-btn"><i class="fas fa-lock"></i> Performance Mode</button>
+        <button id="toggle-chords-btn" class="modal-action-btn" title="Toggle Chords"><i class="fas fa-guitar"></i></button>
+        <button id="toggle-read-only-btn" class="modal-action-btn" title="Performance Mode"><i class="fas fa-lock"></i></button>
         <div class="modal-action-btn">
           <label for="edit-mode-select"><i class="fas fa-edit"></i> Edit Mode</label>
           <select id="edit-mode-select" class="modal-select">
@@ -158,12 +158,12 @@
         <div class="modal-action-btn">
            <i class="fas fa-bullseye"></i> Rhyme Colors   <input type="checkbox" id="rhyme-mode-toggle">
         </div>
-        <button id="save-song-btn" class="modal-action-btn"><i class="fas fa-save"></i> Save Song</button>
-        <button id="copy-lyrics-btn" class="modal-action-btn"><i class="fas fa-copy"></i> Copy Options</button>
-        <button id="undo-btn" class="modal-action-btn"><i class="fas fa-undo"></i> Undo</button>
-        <button id="redo-btn" class="modal-action-btn"><i class="fas fa-redo"></i> Redo</button>
-        <button id="metadata-toggle-btn" class="modal-action-btn"><i class="fas fa-info-circle"></i> Song Metadata</button>
-        <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
+        <button id="save-song-btn" class="modal-action-btn" title="Save Song"><i class="fas fa-save"></i></button>
+        <button id="copy-lyrics-btn" class="modal-action-btn" title="Copy Options"><i class="fas fa-copy"></i></button>
+        <button id="undo-btn" class="modal-action-btn" title="Undo"><i class="fas fa-undo"></i></button>
+        <button id="redo-btn" class="modal-action-btn" title="Redo"><i class="fas fa-redo"></i></button>
+        <button id="metadata-toggle-btn" class="modal-action-btn" title="Song Metadata"><i class="fas fa-info-circle"></i></button>
+        <button class="close-modal-btn" title="Close"><i class="fas fa-times"></i></button>
       </div>
     </div>
 
@@ -171,28 +171,28 @@
       <div class="modal">
         <h2>AI Tools</h2>
         <textarea id="ai-additional-notes" class="ai-notes-input" placeholder="Additional notes..." rows="2"></textarea>
-        <button class="tool-option modal-action-btn" data-prompt="Generate First Draft"><i class="fas fa-magic"></i> Generate First Draft</button>
-        <button class="tool-option modal-action-btn" data-prompt="Polish Lyrics"><i class="fas fa-brush"></i> Polish Lyrics</button>
-        <button class="tool-option modal-action-btn" data-prompt="Rewrite in Different Style"><i class="fas fa-pen"></i> Rewrite in Style</button>
-        <button class="tool-option modal-action-btn" data-prompt="Continue Song"><i class="fas fa-arrow-down"></i> Continue Song</button>
-        <button class="tool-option modal-action-btn" data-prompt="Suggest Chords"><i class="fas fa-guitar"></i> Suggest Chords</button>
-        <button id="ai-format-btn" class="modal-action-btn"><i class="fas fa-broom"></i> Clean Format</button>
-        <button id="regenre-btn" class="modal-action-btn"><i class="fas fa-random"></i> Re-Genre</button>
-        <button id="ai-settings-btn" class="modal-action-btn"><i class="fas fa-cog"></i> Settings</button>
-        <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
+        <button class="tool-option modal-action-btn" data-prompt="Generate First Draft" title="Generate First Draft"><i class="fas fa-magic"></i></button>
+        <button class="tool-option modal-action-btn" data-prompt="Polish Lyrics" title="Polish Lyrics"><i class="fas fa-brush"></i></button>
+        <button class="tool-option modal-action-btn" data-prompt="Rewrite in Different Style" title="Rewrite in Style"><i class="fas fa-pen"></i></button>
+        <button class="tool-option modal-action-btn" data-prompt="Continue Song" title="Continue Song"><i class="fas fa-arrow-down"></i></button>
+        <button class="tool-option modal-action-btn" data-prompt="Suggest Chords" title="Suggest Chords"><i class="fas fa-guitar"></i></button>
+        <button id="ai-format-btn" class="modal-action-btn" title="Clean Format"><i class="fas fa-broom"></i></button>
+        <button id="regenre-btn" class="modal-action-btn" title="Re-Genre"><i class="fas fa-random"></i></button>
+        <button id="ai-settings-btn" class="modal-action-btn" title="Settings"><i class="fas fa-cog"></i></button>
+        <button class="close-modal-btn" title="Close"><i class="fas fa-times"></i></button>
       </div>
     </div>
 
     <div id="add-section-modal" class="modal-overlay">
       <div class="modal">
         <h2>Add Section</h2>
-        <button class="modal-action-btn" data-section="[Intro]"><i class="fas fa-play"></i> Intro</button>
-        <button class="modal-action-btn" data-section="[Pre-Chorus]"><i class="fas fa-step-forward"></i> Pre-Chorus</button>
-        <button class="modal-action-btn" data-section="[Verse]"><i class="fas fa-microphone-alt"></i> Verse</button>
-        <button class="modal-action-btn" data-section="[Chorus]"><i class="fas fa-music"></i> Chorus</button>
-        <button class="modal-action-btn" data-section="[Bridge]"><i class="fas fa-link"></i> Bridge</button>
-        <button class="modal-action-btn" data-section="[Outro]"><i class="fas fa-flag-checkered"></i> Outro</button>
-        <button class="close-modal-btn"><i class="fas fa-times"></i> Close</button>
+        <button class="modal-action-btn" data-section="[Intro]" title="Intro"><i class="fas fa-play"></i></button>
+        <button class="modal-action-btn" data-section="[Pre-Chorus]" title="Pre-Chorus"><i class="fas fa-step-forward"></i></button>
+        <button class="modal-action-btn" data-section="[Verse]" title="Verse"><i class="fas fa-microphone-alt"></i></button>
+        <button class="modal-action-btn" data-section="[Chorus]" title="Chorus"><i class="fas fa-music"></i></button>
+        <button class="modal-action-btn" data-section="[Bridge]" title="Bridge"><i class="fas fa-link"></i></button>
+        <button class="modal-action-btn" data-section="[Outro]" title="Outro"><i class="fas fa-flag-checkered"></i></button>
+        <button class="close-modal-btn" title="Close"><i class="fas fa-times"></i></button>
       </div>
     </div>
 

--- a/hub/hub.html
+++ b/hub/hub.html
@@ -223,7 +223,7 @@
           <i class="fas fa-dice"></i>
           <h3>MuseDice</h3>
           <p>Roll creative seeds: moods, metaphors, images, and lines to spark songs.</p>
-          <button class="btn go">Open</button>
+          <button class="btn go" title="Open"><i class="fas fa-arrow-right"></i></button>
         </a>
 
         <!-- 2. Suno Prompt Engine -->
@@ -231,7 +231,7 @@
           <i class="fas fa-music"></i>
           <h3>Suno Prompt Engine</h3>
           <p>Turn your lyrics into Suno-ready prompts with structured guidance.</p>
-          <button class="btn go">Open</button>
+          <button class="btn go" title="Open"><i class="fas fa-arrow-right"></i></button>
         </a>
 
         <!-- 3. Create New Song -->
@@ -239,7 +239,7 @@
           <i class="fas fa-pen-nib"></i>
           <h3>Create New Song</h3>
           <p>Blank slate in the editor with section scaffolding ready to go.</p>
-          <span class="btn go">Start</span>
+          <span class="btn go" title="Start"><i class="fas fa-play"></i></span>
         </button>
 
         <!-- 4. Settings -->
@@ -247,7 +247,7 @@
           <i class="fas fa-cog"></i>
           <h3>Settings</h3>
           <p>Set your OpenRouter key & model, custom system prompt, and manage export/import.</p>
-          <span class="btn go">Configure</span>
+          <span class="btn go" title="Configure"><i class="fas fa-sliders-h"></i></span>
         </button>
       </section>
     </main>
@@ -280,14 +280,14 @@
 
       <div class="btn-row">
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
-          <button id="saveSettings" class="btn"><i class="fas fa-save"></i> Save</button>
-          <button id="closeSettings" class="btn ghost"><i class="fas fa-times"></i> Close</button>
+          <button id="saveSettings" class="btn" title="Save"><i class="fas fa-save"></i></button>
+          <button id="closeSettings" class="btn ghost" title="Close"><i class="fas fa-times"></i></button>
         </div>
         <div style="display:flex; gap:.5rem; flex-wrap:wrap;">
           <input id="importFile" type="file" accept=".json" style="display:none;" />
-          <button id="exportAll" class="btn"><i class="fas fa-download"></i> Export All</button>
-          <button id="importAll" class="btn"><i class="fas fa-upload"></i> Import</button>
-          <button id="clearAll" class="btn danger"><i class="fas fa-trash"></i> Clear All</button>
+          <button id="exportAll" class="btn" title="Export All"><i class="fas fa-download"></i></button>
+          <button id="importAll" class="btn" title="Import"><i class="fas fa-upload"></i></button>
+          <button id="clearAll" class="btn danger" title="Clear All"><i class="fas fa-trash"></i></button>
         </div>
       </div>
 

--- a/hub/musedice.html
+++ b/hub/musedice.html
@@ -77,12 +77,12 @@
     <div class="wrap">
       <div class="row" style="justify-content:space-between">
         <h1>
-          🎲 MuseDice <span class="badge">Songwriting Spark</span>
+          <i class="fas fa-dice"></i> MuseDice <span class="badge">Songwriting Spark</span>
         </h1>
         <div class="row">
-          <button id="theme-toggle-btn" class="btn ghost small" title="Toggle theme">🌓</button>
-          <button class="btn ghost small" id="btnSettings" title="Settings">⚙️ Settings</button>
-          <button class="btn ghost small" id="btnAbout" title="About">❓ About</button>
+          <button id="theme-toggle-btn" class="btn ghost small" title="Toggle theme"><i class="fas fa-adjust"></i></button>
+          <button class="btn ghost small" id="btnSettings" title="Settings"><i class="fas fa-cog"></i></button>
+          <button class="btn ghost small" id="btnAbout" title="About"><i class="fas fa-question-circle"></i></button>
         </div>
       </div>
       <div id="controls" class="row">
@@ -91,8 +91,8 @@
           <input id="seed" inputmode="numeric" placeholder="leave blank for fresh chaos" />
         </div>
         <div class="row">
-          <button class="btn icon primary" id="btnRoll" title="Shuffle all (unlocked)">🎲</button>
-          <button class="btn accent" id="btnWrite">✍️ Write lyric <span class="spinner" id="spinWrite"></span></button>
+          <button class="btn icon primary" id="btnRoll" title="Shuffle all (unlocked)"><i class="fas fa-dice"></i></button>
+          <button class="btn accent" id="btnWrite" title="Write lyric"><i class="fas fa-pen"></i><span class="spinner" id="spinWrite"></span></button>
         </div>
       </div>
     </div>
@@ -105,18 +105,18 @@
       <div class="row" style="justify-content:space-between">
         <strong>AI Output</strong>
         <div class="row">
-          <button class="btn small ghost" id="btnCopy">Copy</button>
-          <button class="btn small ghost" id="btnClear">Clear</button>
-          <button class="btn small" id="btnExport">Export JSON</button>
-          <label class="btn small warn" for="importFile" title="Import JSON">Import<input id="importFile" type="file" accept="application/json" style="display:none"></label>
+          <button class="btn small ghost" id="btnCopy" title="Copy"><i class="fas fa-copy"></i></button>
+          <button class="btn small ghost" id="btnClear" title="Clear"><i class="fas fa-times"></i></button>
+          <button class="btn small" id="btnExport" title="Export JSON"><i class="fas fa-file-export"></i></button>
+          <label class="btn small warn" for="importFile" title="Import JSON"><i class="fas fa-file-import"></i><input id="importFile" type="file" accept="application/json" style="display:none"></label>
         </div>
       </div>
-      <textarea id="aiText" placeholder="Click ✍️ Write lyric (with an API key in Settings) — or just use the dice to get offline prompts."></textarea>
+      <textarea id="aiText" placeholder="Click Write lyric (with an API key in Settings) — or just use the dice to get offline prompts."></textarea>
     </section>
 
     <footer>
       <div class="pill">Offline: fully usable with random prompts • Online: add an OpenRouter API key for AI writing</div>
-      <div style="margin-top:10px" class="tips">Pro tip: lock any card you love, then hit 🎲 to remix the rest. Long‑press on a card to regenerate only that card.</div>
+      <div style="margin-top:10px" class="tips">Pro tip: lock any card you love, then hit <i class="fas fa-dice"></i> to remix the rest. Long‑press on a card to regenerate only that card.</div>
     </footer>
   </main>
 
@@ -125,7 +125,7 @@
     <div class="modal">
       <div class="row" style="justify-content:space-between;align-items:center">
         <strong>Settings</strong>
-        <button class="btn small ghost" id="btnClose">Close</button>
+        <button class="btn small ghost" id="btnClose" title="Close"><i class="fas fa-times"></i></button>
       </div>
       <div class="grid two">
         <div class="field">
@@ -156,8 +156,8 @@
       </div>
       <div class="tips">Your key never leaves this device except to call OpenRouter directly from your browser. <span class="kbd">Esc</span> to close.</div>
       <div class="row" style="margin-top:10px">
-        <button class="btn primary" id="btnSave">Save</button>
-        <button class="btn ghost" id="btnClearKey">Remove key</button>
+        <button class="btn primary" id="btnSave" title="Save"><i class="fas fa-save"></i></button>
+        <button class="btn ghost" id="btnClearKey" title="Remove key"><i class="fas fa-key"></i></button>
       </div>
     </div>
   </dialog>
@@ -167,7 +167,7 @@
     <div class="modal">
       <div class="row" style="justify-content:space-between;align-items:center">
         <strong>About MuseDice</strong>
-        <button class="btn small ghost" id="btnAboutClose">Close</button>
+        <button class="btn small ghost" id="btnAboutClose" title="Close"><i class="fas fa-times"></i></button>
       </div>
       <p>MuseDice generates <em>structured randomness</em> for songwriting: themes, settings, POV, constraints, imagery, hooks, and chord ideas. Lock what you like, roll the rest. If you add an OpenRouter key, MuseDice will also draft lyrics and a focused brief based on your current deck.</p>
       <p class="tips">Single‑file, mobile‑first, no build step. Host anywhere, or open locally.</p>
@@ -264,11 +264,11 @@
       card.innerHTML = `
         <h3><span>${def.label}</span>
           <span class="locks">
-            <button class="btn small ghost lockBtn" aria-pressed="${locked}" title="Lock/unlock">${locked?'🔒':'🔓'}</button>
-            <button class="btn small ghost oneBtn" title="Regenerate this">↻</button>
+            <button class="btn small ghost lockBtn" aria-pressed="${locked}" title="Lock/unlock"><i class="fas ${locked?'fa-lock':'fa-unlock'}"></i></button>
+            <button class="btn small ghost oneBtn" title="Regenerate this"><i class="fas fa-sync"></i></button>
           </span>
         </h3>
-        <div class="value">${val||'<span style="color:var(--muted)">— roll the dice —</span>'}</div>
+        <div class="value">${val||'<span style=\"color:var(--muted)\">— roll the dice —</span>'}</div>
       `;
       // Events
       card.querySelector('.lockBtn').onclick=()=>{ STATE.locks[def.key]=!locked; renderCards(); saveLocal(); };

--- a/hub/sunopromptengine.html
+++ b/hub/sunopromptengine.html
@@ -85,10 +85,10 @@
         </div>
       </div>
       <div class="toolbar">
-        <button id="theme-toggle-btn" class="btn ghost" title="Toggle theme">🌓 Theme</button>
-        <button id="aboutBtn" class="btn ghost">About</button>
-        <button id="filesBtn" class="btn ghost">Files</button>
-        <button id="settingsBtn" class="btn">⚙️ Settings</button>
+        <button id="theme-toggle-btn" class="btn ghost" title="Toggle theme"><i class="fas fa-adjust"></i></button>
+        <button id="aboutBtn" class="btn ghost" title="About"><i class="fas fa-info-circle"></i></button>
+        <button id="filesBtn" class="btn ghost" title="Files"><i class="fas fa-folder-open"></i></button>
+        <button id="settingsBtn" class="btn" title="Settings"><i class="fas fa-cog"></i></button>
       </div>
     </div>
   </header>
@@ -115,7 +115,7 @@
           <input id="seed" type="number" inputmode="numeric" placeholder="optional" class="" style="width:120px"/>
         </div>
         <div class="spacer"></div>
-        <button id="sendBtn" class="btn primary">▶ Generate</button>
+        <button id="sendBtn" class="btn primary" title="Generate"><i class="fas fa-play"></i></button>
       </div>
 
       <details id="advanced">
@@ -129,7 +129,7 @@
         <h3>1 • Natural language description</h3>
         <pre id="outDescription" aria-live="polite"></pre>
         <div class="row" style="margin-top:8px;">
-          <button class="btn" data-copy="outDescription">Copy</button>
+          <button class="btn" data-copy="outDescription" title="Copy"><i class="fas fa-copy"></i></button>
           <span class="spacer"></span>
           <span class="status" id="descCount">0 chars</span>
         </div>
@@ -138,7 +138,7 @@
         <h3>2 • Style meta tags</h3>
         <pre id="outStyle" aria-live="polite"></pre>
         <div class="row" style="margin-top:8px;">
-          <button class="btn" data-copy="outStyle">Copy</button>
+          <button class="btn" data-copy="outStyle" title="Copy"><i class="fas fa-copy"></i></button>
           <span class="spacer"></span>
           <span class="status" id="styleCount">0 chars</span>
         </div>
@@ -147,7 +147,7 @@
         <h3>3 • Exclude metatags</h3>
         <pre id="outExclude" aria-live="polite"></pre>
         <div class="row" style="margin-top:8px;">
-          <button class="btn" data-copy="outExclude">Copy</button>
+          <button class="btn" data-copy="outExclude" title="Copy"><i class="fas fa-copy"></i></button>
           <span class="spacer"></span>
           <span class="status" id="excludeCount">0 chars</span>
         </div>
@@ -156,9 +156,9 @@
 
     <section class="card" style="margin-top:12px;">
       <div class="row">
-        <button id="exportTxt" class="btn">⬇ Export All (.txt)</button>
-        <button id="saveLocal" class="btn">💾 Save</button>
-        <button id="clearAll" class="btn danger">✖ Clear</button>
+        <button id="exportTxt" class="btn" title="Export All"><i class="fas fa-file-export"></i></button>
+        <button id="saveLocal" class="btn" title="Save"><i class="fas fa-save"></i></button>
+        <button id="clearAll" class="btn danger" title="Clear"><i class="fas fa-times"></i></button>
         <div class="spacer"></div>
         <small class="muted">Tips: <span class="kbd">Ctrl/Cmd+Enter</span> to generate • <span class="kbd">Ctrl/Cmd+K</span> to focus input</small>
       </div>
@@ -169,13 +169,13 @@
   <dialog id="settingsModal">
     <div class="modal-head">
       <strong>Settings</strong>
-      <button class="btn ghost" data-close="settingsModal">Close</button>
+      <button class="btn ghost" data-close="settingsModal" title="Close"><i class="fas fa-times"></i></button>
     </div>
     <div class="modal-body">
       <label class="muted" for="apiKey">OpenRouter API Key</label>
       <input id="apiKey" type="password" placeholder="sk-or-v1-..." autocomplete="off"/>
       <div class="row" style="margin:8px 0;">
-        <button id="fetchModels" class="btn">🔄 Fetch Models</button>
+        <button id="fetchModels" class="btn" title="Fetch Models"><i class="fas fa-sync"></i></button>
         <div class="spacer"></div>
         <label class="muted" for="themeSelect">Theme</label>
         <select id="themeSelect">
@@ -195,7 +195,7 @@
   <dialog id="aboutModal">
     <div class="modal-head">
       <strong>About</strong>
-      <button class="btn ghost" data-close="aboutModal">Close</button>
+      <button class="btn ghost" data-close="aboutModal" title="Close"><i class="fas fa-times"></i></button>
     </div>
     <div class="modal-body">
       <p><strong>Suno Prompt Engine</strong> is a mobile‑first, light/dark, production‑ready web app that crafts Suno v4.5 prompts using OpenRouter models. Nothing leaves your browser except direct API calls you make with your key (stored locally). You can edit the system prompt and export the outputs.</p>
@@ -213,13 +213,13 @@
   <dialog id="filesModal">
     <div class="modal-head">
       <strong>Files</strong>
-      <button class="btn ghost" data-close="filesModal">Close</button>
+      <button class="btn ghost" data-close="filesModal" title="Close"><i class="fas fa-times"></i></button>
     </div>
     <div class="modal-body">
       <div class="row" style="margin-bottom:8px;">
-        <button id="exportAllLocal" class="btn">Export All Saved (.zip)</button>
+        <button id="exportAllLocal" class="btn" title="Export All Saved"><i class="fas fa-file-export"></i></button>
         <div class="spacer"></div>
-        <button id="clearSaved" class="btn danger">Clear Saved</button>
+        <button id="clearSaved" class="btn danger" title="Clear Saved"><i class="fas fa-trash"></i></button>
       </div>
       <div id="savedList" class="list" role="listbox" aria-label="Saved prompts"></div>
     </div>
@@ -316,9 +316,9 @@
         const item = document.createElement('div'); item.className='item'; item.role='option';
         item.innerHTML = `<div><strong>${e.model||'model?'}</strong> <small class="muted">• ${d}</small><br><small class="muted">${(e.idea||'').slice(0,80)}${(e.idea||'').length>80?'…':''}</small></div>
           <div class="row">
-            <button class="btn" data-load="${idx}">Load</button>
-            <button class="btn" data-download="${idx}">.txt</button>
-            <button class="btn danger" data-delete="${idx}">Delete</button>
+            <button class="btn" data-load="${idx}" title="Load"><i class="fas fa-file-import"></i></button>
+            <button class="btn" data-download="${idx}" title="Download"><i class="fas fa-file-download"></i></button>
+            <button class="btn danger" data-delete="${idx}" title="Delete"><i class="fas fa-trash"></i></button>
           </div>`;
         box.appendChild(item);
       });
@@ -423,7 +423,7 @@
       arr.forEach(m => {
         const div = document.createElement('div'); div.className='item'; div.role='option';
         const price = m.pricing ? `${m.pricing.prompt_token || m.pricing.input || ''}/${m.pricing.completion_token || m.pricing.output || ''}` : '';
-        div.innerHTML = `<div><strong>${m.name||m.id}</strong><br><small class="muted">${m.id}${price?` • ${price}`:''}</small></div><button class="btn" data-pick="${m.id}">Select</button>`;
+        div.innerHTML = `<div><strong>${m.name||m.id}</strong><br><small class="muted">${m.id}${price?` • ${price}`:''}</small></div><button class="btn" data-pick="${m.id}" title="Select"><i class="fas fa-check"></i></button>`;
         list.appendChild(div);
       });
     }

--- a/index.html
+++ b/index.html
@@ -79,9 +79,9 @@
             </div>
 
             <div class="controls">
-              <button id="md-roll" class="btn-primary"><i class="fas fa-dice"></i> Roll</button>
-              <button id="md-lock-seed" class="btn-ghost"><i class="fas fa-lock"></i> Seed</button>
-              <button id="md-copy" class="btn-ghost"><i class="fas fa-copy"></i> Copy</button>
+              <button id="md-roll" class="btn-primary" title="Roll"><i class="fas fa-dice"></i></button>
+              <button id="md-lock-seed" class="btn-ghost" title="Seed Lock"><i class="fas fa-lock"></i></button>
+              <button id="md-copy" class="btn-ghost" title="Copy"><i class="fas fa-copy"></i></button>
               <span id="md-seed" class="seed">seed: —</span>
             </div>
           </div>
@@ -147,9 +147,9 @@
             </div>
 
             <div class="controls">
-              <button id="s-generate" class="btn-primary"><i class="fas fa-wand-magic"></i> Build A/B</button>
-              <button id="s-copy-a" class="btn-ghost"><i class="fas fa-copy"></i> Copy A</button>
-              <button id="s-copy-b" class="btn-ghost"><i class="fas fa-copy"></i> Copy B</button>
+              <button id="s-generate" class="btn-primary" title="Build A/B"><i class="fas fa-wand-magic"></i></button>
+              <button id="s-copy-a" class="btn-ghost" title="Copy A"><i class="fas fa-copy"></i></button>
+              <button id="s-copy-b" class="btn-ghost" title="Copy B"><i class="fas fa-copy"></i></button>
               <span id="s-count" class="seed">0 chars</span>
             </div>
           </div>

--- a/script.js
+++ b/script.js
@@ -754,8 +754,8 @@ Turnaround: ${pick(['ii–V–I','♭VII → I','IV → V'])}`;
   el('md-roll')?.addEventListener('click', roll);
   el('md-lock-seed')?.addEventListener('click', ()=>{
     locked=!locked; el('md-lock-seed').innerHTML = locked
-      ? '<i class="fas fa-lock"></i> Seed'
-      : '<i class="fas fa-unlock"></i> Seed';
+      ? '<i class="fas fa-lock"></i>'
+      : '<i class="fas fa-unlock"></i>';
   });
   el('md-copy')?.addEventListener('click', async ()=>{
     const out = `# MuseDice Brief\n\n${el('md-brief-out').value}\n\n## Chords\n${el('md-chords-out').value}\n\n## Lyric Starters\n${el('md-lyrics-out').value}`;

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -10,11 +10,12 @@ export default function ThemeToggle() {
           key={opt}
           role="radio"
           aria-checked={mode===opt}
+          aria-label={opt}
           onClick={() => setMode(opt)}
           className={`px-3 py-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-focus
                       ${mode===opt ? 'bg-primary text-cream shadow-glow' : 'hover:bg-muted/10'}`}
         >
-          {opt}
+          <i className={`fas fa-${opt==='light'?'sun':opt==='dark'?'moon':'desktop'}`}></i>
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- replace text labels and emoji buttons across the hub, MuseDice, Suno Prompt Engine and editor with Font Awesome icons
- switch React theme toggle to icon-only buttons
- adjust seed lock toggle and other controls to rely on icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5e4ebd884832a8540da8de73da3de