### PR TITLE
Add install banner for PWA and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ LyricSmith is a fully installable PWA with offline support powered by a service 
 
 1. Serve the project over HTTPS (e.g. `npx http-server -p 8080`).
 2. Open the site in Chrome and visit **Application → Manifest** in DevTools to verify install readiness.
-3. Use the built in install banner or Chrome's install option to add the app to your device.
+3. In **Application → Service Workers**, confirm the worker is installed and `lyricsmith-v3` cache exists.
+4. Toggle **Offline** in DevTools to verify pages continue to work without a network.
+5. Use the built-in install banner or Chrome's install option to add the app to your device.
 
 ### Generate an Android APK with Bubblewrap
 
 1. Install Bubblewrap globally: `npm i -g @bubblewrap/cli`.
-2. Initialize: `bubblewrap init --manifest https://your-domain/manifest.webmanifest`.
+2. Initialize: `npx bubblewrap init --manifest=manifest.webmanifest --asset-prefix=/ --base-uri=/`.
 3. Build the project: `bubblewrap build`.
 4. Sign and install the generated APK on your device.
 

--- a/index.html
+++ b/index.html
@@ -168,6 +168,11 @@
       </section>
     </main>
   </div>
+  <div id="install-banner" class="install-banner" role="dialog" aria-label="Install LyricSmith">
+    <span>Install LyricSmith?</span>
+    <button id="install-btn" class="btn-primary">Install</button>
+    <button id="close-install" class="btn-ghost">Not now</button>
+  </div>
     <script>
         // Register service worker and check for updates
         if ('serviceWorker' in navigator) {
@@ -208,5 +213,6 @@
         }
     </script>
     <script src="script.js"></script>
+    <script src="js/pwa.js"></script>
 </body>
 </html>

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,34 @@
+// Handle PWA install banner
+let deferredPrompt;
+const banner = document.getElementById('install-banner');
+const installBtn = document.getElementById('install-btn');
+const closeBtn = document.getElementById('close-install');
+
+function dismissedThisSession() {
+  return sessionStorage.getItem('pwaDismissed') === '1';
+}
+
+window.addEventListener('beforeinstallprompt', (e) => {
+  if (dismissedThisSession() ||
+      window.matchMedia('(display-mode: standalone)').matches ||
+      window.navigator.standalone) {
+    return;
+  }
+  e.preventDefault();
+  deferredPrompt = e;
+  banner?.classList.add('show');
+});
+
+installBtn?.addEventListener('click', async () => {
+  banner.classList.remove('show');
+  sessionStorage.setItem('pwaDismissed', '1');
+  if (!deferredPrompt) return;
+  deferredPrompt.prompt();
+  await deferredPrompt.userChoice;
+  deferredPrompt = null;
+});
+
+closeBtn?.addEventListener('click', () => {
+  banner.classList.remove('show');
+  sessionStorage.setItem('pwaDismissed', '1');
+});

--- a/style.css
+++ b/style.css
@@ -1730,3 +1730,22 @@ html, body {
 .toast-success { background: var(--grad-accent); }
 .toast-error { background: var(--grad-primary); }
 
+/* Install banner */
+#install-banner {
+  position: fixed;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--grad-primary);
+  color: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--border-radius-base);
+  box-shadow: var(--shadow-lg);
+  display: none;
+  align-items: center;
+  gap: 0.75rem;
+  z-index: 1000;
+}
+
+#install-banner.show { display: flex; }
+


### PR DESCRIPTION
## Summary
- add custom install banner and handler to prompt for PWA installation
- document service worker, offline testing, and Bubblewrap initialization steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6a761575c832aa8037c40e7642773