### PR TITLE
Add performance footer and modal fixes

### DIFF
--- a/performance.css
+++ b/performance.css
@@ -1,0 +1,73 @@
+.performance-mode-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  z-index: 1000;
+}
+
+.performance-header {
+  position: sticky;
+  top: 0;
+  background: var(--gradient-primary);
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border-light);
+  z-index: 1010;
+}
+
+.performance-footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 56px;
+  background: var(--gradient-primary);
+  border-top: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  z-index: 2025;
+}
+
+.performance-footer button {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 1.2rem;
+}
+
+.auto-scroll-btn,
+.scroll-to-top-btn {
+  position: fixed;
+  right: 1rem;
+  bottom: 72px;
+  z-index: 2020;
+}
+
+#performance-menu-modal,
+#perf-metadata-modal,
+#autoscroll-delay-modal {
+  z-index: 20050;
+}
+
+.modal-content {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  padding: 1rem;
+  border-radius: var(--border-radius-base);
+  min-width: 280px;
+}
+
+.modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: var(--text-primary);
+}

--- a/performance.html
+++ b/performance.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>Performance Mode</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="performance.css">
+</head>
+<body>
+  <div id="performance-mode" class="performance-mode-overlay" data-song-id="">
+    <header class="performance-header">
+      <h1 class="song-title">Song Title</h1>
+      <!-- Header font controls intentionally removed to avoid duplicates -->
+    </header>
+
+    <main id="lyrics" class="lyrics-content">
+      <p>Lyrics will appear here...</p>
+    </main>
+
+    <div class="performance-footer">
+      <button id="footer-decrease-font-btn" aria-label="Decrease font size">−</button>
+      <span id="footer-font-size-display">16px</span>
+      <button id="footer-increase-font-btn" aria-label="Increase font size">+</button>
+      <button id="footer-autoscroll-settings-btn" class="footer-action" aria-label="Autoscroll settings">
+        <i class="fas fa-clock"></i>
+      </button>
+      <button id="footer-perf-menu-btn" class="footer-action" aria-label="Performance menu">
+        <i class="fas fa-ellipsis-v"></i>
+      </button>
+      <button id="footer-theme-toggle-btn" class="footer-action" aria-label="Toggle theme">
+        <i class="fas fa-adjust"></i>
+      </button>
+      <button id="footer-exit-performance-btn" class="footer-action" aria-label="Exit performance mode">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+
+    <div id="performance-menu-modal" class="modal">
+      <div class="modal-content">
+        <button class="modal-close" aria-label="Close">&times;</button>
+        <p>Performance menu</p>
+      </div>
+    </div>
+
+    <div id="perf-metadata-modal" class="modal">
+      <div class="modal-content">
+        <button class="modal-close" aria-label="Close">&times;</button>
+        <p>Song metadata</p>
+      </div>
+    </div>
+
+    <div id="autoscroll-delay-modal" class="modal">
+      <div class="modal-content">
+        <button class="modal-close" aria-label="Close">&times;</button>
+        <p>Autoscroll delay settings</p>
+      </div>
+    </div>
+  </div>
+
+  <script src="performance.js"></script>
+</body>
+</html>

--- a/performance.js
+++ b/performance.js
@@ -1,0 +1,62 @@
+(function(){
+  const fontSizeStep = 2;
+  const perSongFontSizes = JSON.parse(localStorage.getItem('perSongFontSizes') || '{}');
+  const songId = new URLSearchParams(location.search).get('songId') || 'default';
+  const lyricsEl = document.getElementById('lyrics');
+
+  let currentFontSize = perSongFontSizes[songId] || 16;
+  applyFontSize();
+
+  function applyFontSize(){
+    if (lyricsEl) {
+      lyricsEl.style.fontSize = currentFontSize + 'px';
+    }
+    updateFontSize();
+  }
+
+  function updateFontSize(){
+    const footerDisplay = document.getElementById('footer-font-size-display');
+    if (footerDisplay) footerDisplay.textContent = currentFontSize + 'px';
+    const headerDisplay = document.getElementById('font-size-display');
+    if (headerDisplay) headerDisplay.textContent = currentFontSize + 'px';
+  }
+
+  function adjustFontSize(delta){
+    currentFontSize = Math.max(8, currentFontSize + delta);
+    perSongFontSizes[songId] = currentFontSize;
+    localStorage.setItem('perSongFontSizes', JSON.stringify(perSongFontSizes));
+    applyFontSize();
+  }
+
+  document.getElementById('footer-decrease-font-btn')?.addEventListener('click', () => adjustFontSize(-fontSizeStep));
+  document.getElementById('footer-increase-font-btn')?.addEventListener('click', () => adjustFontSize(fontSizeStep));
+
+  // Modal helpers
+  function closeModals(){
+    document.querySelectorAll('.modal.is-open').forEach(m => m.classList.remove('is-open'));
+  }
+  function openModal(id){
+    const m = document.getElementById(id);
+    if (m) m.classList.add('is-open');
+  }
+
+  document.querySelectorAll('.modal-close').forEach(btn => btn.addEventListener('click', closeModals));
+
+  document.getElementById('footer-perf-menu-btn')?.addEventListener('click', () => openModal('performance-menu-modal'));
+  document.getElementById('footer-autoscroll-settings-btn')?.addEventListener('click', () => openModal('autoscroll-delay-modal'));
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') closeModals();
+  });
+
+  // Theme toggle
+  document.getElementById('footer-theme-toggle-btn')?.addEventListener('click', () => {
+    const current = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+    document.documentElement.dataset.theme = current;
+    localStorage.setItem('theme', current);
+  });
+
+  document.getElementById('footer-exit-performance-btn')?.addEventListener('click', () => {
+    window.location.href = '/';
+  });
+})();

--- a/style.css
+++ b/style.css
@@ -1730,3 +1730,18 @@ html, body {
     color: var(--bg-primary);
     transform: scale(1.05);
 }
+
+/* Global modal styles */
+.modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  align-items: center;
+  justify-content: center;
+  z-index: 20010;
+}
+
+.modal.is-open {
+  display: flex;
+}

--- a/sw.js
+++ b/sw.js
@@ -1,10 +1,13 @@
-const CACHE_NAME = 'lyricsmith-cache-v2';
+const CACHE_NAME = 'lyricsmith-cache-v3';
 const APP_SHELL = [
   '/',
   '/index.html',
   '/style.css',
   '/script.js',
   '/songs.js',
+  '/performance.html',
+  '/performance.css',
+  '/performance.js',
   '/editor/editor.html',
   '/hub/hub.html',
   '/hub/musedice.html',


### PR DESCRIPTION
## Summary
- Add performance mode page with sticky footer housing font controls and quick actions
- Style footer and adjust floating buttons and modal stacking layers
- Update service worker cache to include performance assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc81f701c832ab05347e28a2e0dab